### PR TITLE
Place Git workdirs in private storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,8 +16,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
 
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
-
     <!-- For BroadcastReceiver below -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 

--- a/app/src/main/java/com/orgzly/android/git/GitPreferencesFromRepoPrefs.java
+++ b/app/src/main/java/com/orgzly/android/git/GitPreferencesFromRepoPrefs.java
@@ -42,8 +42,9 @@ public class GitPreferencesFromRepoPrefs implements GitPreferences {
     public String repositoryFilepath() {
         return repoPreferences.getStringValueWithGlobalDefault(
                 R.string.pref_key_git_repository_filepath,
-                AppPreferences.repositoryStoragePathForUri(
-                        repoPreferences.getContext(), remoteUri()));
+                AppPreferences.gitRepoStoragePathForRepoId(
+                        repoPreferences.getContext(),
+                        repoPreferences.getRepoId()));
     }
 
     @Override

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -916,31 +916,11 @@ public class AppPreferences {
                 context.getResources().getString(R.string.pref_key_git_is_enabled),
                 context.getResources().getBoolean(R.bool.pref_default_git_is_enabled));
     }
-    
-    public static String defaultRepositoryStorageDirectory(Context context) {
-        File path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-        return getStringFromSelector(
-                context, R.string.pref_key_git_default_repository_directory, path.toString());
+
+    public static String gitRepoStoragePathForRepoId(Context context, Long repoId)  {
+        return new File(context.getCacheDir(), "gitrepo" + repoId).getAbsolutePath();
     }
 
-    public static String repositoryStoragePathForUri(Context context, Uri repoUri)  {
-        String directoryFilename = repoUri.toString();
-        try {
-            directoryFilename = new URIish(directoryFilename).getPath();
-        } catch (URISyntaxException e) {
-            directoryFilename = directoryFilename.replaceAll("/[^A-Za-z0-9 ]/", "");
-        }
-        Uri baseUri = Uri.parse(defaultRepositoryStorageDirectory(context));
-        return baseUri.buildUpon().appendPath(directoryFilename).build().getPath();
-    }
-
-    private static String getStringFromSelector(Context context, int selector, String def) {
-        return getStateSharedPreferences(context).getString(getSelector(context, selector), def);
-    }
-
-    private static String getSelector(Context context, int selector) {
-        return context.getResources().getString(selector);
-    }
 
     /*
      * Last used version.

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -132,14 +132,8 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
      */
     private static Git cloneRepo(Uri repoUri, File directoryFile, GitTransportSetter transportSetter,
                       ProgressMonitor pm) throws IOException {
-        if (!directoryFile.exists()) {
-            throw new IOException(String.format("The directory %s does not exist", directoryFile.toString()), new FileNotFoundException());
-        }
-
-        // Using list() can be resource intensive if there's many files, but since we just call it
-        // at the time of cloning once we should be fine for now
-        if (directoryFile.list().length != 0) {
-            throw new IOException(String.format("The directory must be empty"), new DirectoryNotEmpty(directoryFile));
+        if (!directoryFile.mkdir()) {
+            throw new IOException(String.format("Failed to create Git workdir %s", directoryFile));
         }
 
         try {

--- a/app/src/main/java/com/orgzly/android/ui/repo/RepoViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/RepoViewModel.kt
@@ -11,6 +11,7 @@ import com.orgzly.android.ui.SingleLiveEvent
 import com.orgzly.android.usecase.RepoCreate
 import com.orgzly.android.usecase.RepoUpdate
 import com.orgzly.android.usecase.UseCase
+import com.orgzly.android.usecase.UseCaseResult
 import com.orgzly.android.usecase.UseCaseRunner
 
 open class RepoViewModel(private val dataRepository: DataRepository, open var repoId: Long) : CommonViewModel() {

--- a/app/src/main/java/com/orgzly/android/ui/repos/ReposActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repos/ReposActivity.kt
@@ -1,13 +1,9 @@
 package com.orgzly.android.ui.repos
 
 import android.Manifest
-import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.os.Environment
-import android.provider.Settings
 import android.view.ContextMenu
 import android.view.MenuItem
 import android.view.View
@@ -32,7 +28,6 @@ import com.orgzly.android.ui.repo.webdav.WebdavRepoActivity
 import com.orgzly.android.ui.showSnackbar
 import com.orgzly.databinding.ActivityReposBinding
 import javax.inject.Inject
-
 
 /**
  * List of user-configured repositories.
@@ -225,18 +220,14 @@ class ReposActivity : CommonActivity(), AdapterView.OnItemClickListener, Activit
             }
 
             R.id.repos_options_menu_item_new_git -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
-                    val uri = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
-                    startActivity(
-                        Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, uri))
-                } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R && ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+                    GitRepoActivity.start(this)
+                } else {
                     // TODO: Show explanation why possibly, if ActivityCompat.shouldShowRequestPermissionRationale() says so?
                     ActivityCompat.requestPermissions(
                         this,
                         arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
                         ACTIVITY_REQUEST_CODE_FOR_READ_WRITE_EXTERNAL_STORAGE)
-                } else {
-                    GitRepoActivity.start(this)
                 }
                 return
             }

--- a/app/src/main/res/layout/activity_repo_git.xml
+++ b/app/src/main/res/layout/activity_repo_git.xml
@@ -37,38 +37,6 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
-            <!-- Directory -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/space_between_content_areas"
-                android:orientation="horizontal">
-
-                <Button
-                    android:id="@+id/activity_repo_git_directory_browse"
-                    style="@style/Button.Repo"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/screen_edge"
-                    android:text="@string/browse" />
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/activity_repo_git_directory_layout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:errorEnabled="true">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/activity_repo_git_directory"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:hint="@string/git_directory_hint"
-                        android:inputType="text" />
-
-                </com.google.android.material.textfield.TextInputLayout>
-
-            </LinearLayout>
-
             <LinearLayout
                 android:id="@+id/activity_repo_git_https_auth_info"
                 android:layout_width="match_parent"


### PR DESCRIPTION
and remove all Git settings related to the workdir location.

The directory containing the workdir is named using the repo ID. This
should allow changing the URL of an existing repo.

I thought for a while about a feature to copy/export the directory to
public storage for troubleshooting purposes, but I came to the
conclusion that it should not be necessary. If the user is worried about
losing local state, they can always export the relevant notebooks as
text files, and re-import them later. If the repo is somehow broken, it
is best to delete it and add a new one, re-linking the notebooks (and
deleting the local copies, if necessary). If there are tenacious bugs,
they should be ironed out on a virtual device with full root access.

This resolves #21.