### PR TITLE
Git: Ensure repo is explored for notebooks if no linked books are found

### DIFF
--- a/app/src/main/java/com/orgzly/android/sync/SyncUtils.kt
+++ b/app/src/main/java/com/orgzly/android/sync/SyncUtils.kt
@@ -37,11 +37,13 @@ object SyncUtils {
                         }
                     }
                 }
-            } else {
-                val libBooks = repo.books
-                /* Each book in repository. */
-                result.addAll(libBooks)
+                if (result.isNotEmpty()) {
+                    continue
+                }
             }
+            val libBooks = repo.books
+            /* Each book in repository. */
+            result.addAll(libBooks)
         }
         return result
     }


### PR DESCRIPTION
This solves the most pressing problem in #22, which was that no notebooks were loaded after cloning a repo (since no new commits were fetched).