### PR TITLE
Show ranged timestamps in agenda queries

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/AgendaFragmentTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/AgendaFragmentTest.java
@@ -103,6 +103,19 @@ public class AgendaFragmentTest extends OrgzlyTest {
     }
 
     @Test
+    public void testAgendaRangeEvent() {
+        DateTime start = DateTime.now().withTimeAtStartOfDay();
+        DateTime end = DateTime.now().withTimeAtStartOfDay().plusDays(4);
+        testUtils.setupBook("book", "Book for testing\n" +
+                            "* Event A.\n" +
+                            "<" + start.toString() + ">--<" + end.toString() + ">\n");
+
+        ActivityScenario.launch(MainActivity.class);
+        searchForText("ad.5");
+        onNotesInAgenda().check(matches(recyclerViewItemCount(10)));
+    }
+
+    @Test
     public void testOneTimeTaskMarkedDone() {
         defaultSetUp();
         searchForText(".it.done ad.7");

--- a/app/src/main/java/com/orgzly/android/db/dao/NoteViewDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/NoteViewDao.kt
@@ -150,7 +150,7 @@ abstract class NoteViewDao {
             t_clock_timestamps_start.string AS clock_time_string,
             t_clock_timestamps_end.string AS clock_time_end_string,
 
-            t_note_events_start.string AS event_string,
+            t_note_events_range.string AS event_string,
             t_note_events_start.timestamp AS event_timestamp,
             datetime(t_note_events_start.timestamp/1000, 'unixepoch', 'localtime', 'start of day') AS event_start_of_day,
             t_note_events_start.hour AS event_hour,


### PR DESCRIPTION
By using the full range as a string in `NoteView` instead of the event start string the rest works automatically.

See https://github.com/orgzly/orgzly-android/issues/602 for more context.