### PR TITLE
Hide empty days in agenda

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -814,6 +814,16 @@ public class AppPreferences {
     }
 
     /*
+     * Hide empty days in agenda
+     */
+
+    public static boolean hideEmptyDaysInAgenda(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_hide_empty_days_in_agenda),
+                context.getResources().getBoolean(R.bool.pref_default_hide_empty_days_in_agenda));
+    }
+
+    /*
      * Widget
      */
 

--- a/app/src/main/java/com/orgzly/android/sync/SyncUtils.kt
+++ b/app/src/main/java/com/orgzly/android/sync/SyncUtils.kt
@@ -37,11 +37,13 @@ object SyncUtils {
                         }
                     }
                 }
-            } else {
-                val libBooks = repo.books
-                /* Each book in repository. */
-                result.addAll(libBooks)
+                if (result.isNotEmpty()) {
+                    continue
+                }
             }
+            val libBooks = repo.books
+            /* Each book in repository. */
+            result.addAll(libBooks)
         }
         return result
     }

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
@@ -229,7 +229,8 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
         viewModel.data.observe(viewLifecycleOwner, Observer { notes ->
             if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, "Observed notes: ${notes.size}")
 
-            val items = AgendaItems.getList(notes, currentQuery, item2databaseIds)
+            val hideEmptyDaysInAgenda = AppPreferences.hideEmptyDaysInAgenda(context)
+            val items = AgendaItems(hideEmptyDaysInAgenda).getList(notes, currentQuery, item2databaseIds)
 
             if (BuildConfig.LOG_DEBUG)
                 LogUtils.d(TAG, "Replacing data with ${items.size} agenda items")

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaItems.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaItems.kt
@@ -9,7 +9,7 @@ import com.orgzly.org.datetime.OrgInterval
 import com.orgzly.org.datetime.OrgRange
 import org.joda.time.DateTime
 
-object AgendaItems {
+class AgendaItems(private val hideEmptyDaysInAgenda : Boolean) {
     data class ExpandableOrgRange(
             val range: OrgRange,
             val canBeOverdueToday: Boolean,
@@ -136,8 +136,9 @@ object AgendaItems {
 
         // Add daily
         dailyNotes.forEach { d ->
-            // Always add day heading
-            result.add(AgendaItem.Day(agendaItemId++, DateTime(d.key)))
+            if (d.value.isNotEmpty() || !hideEmptyDaysInAgenda) {
+                result.add(AgendaItem.Day(agendaItemId++, DateTime(d.key)))
+            }
 
             if (d.value.isNotEmpty()) {
                 result.addAll(d.value)

--- a/app/src/main/java/com/orgzly/android/widgets/ListWidgetService.kt
+++ b/app/src/main/java/com/orgzly/android/widgets/ListWidgetService.kt
@@ -90,7 +90,8 @@ class ListWidgetService : RemoteViewsService() {
 
             if (query.isAgenda()) {
                 val idMap = mutableMapOf<Long, Long>()
-                val agendaItems = AgendaItems.getList(notes, query, idMap)
+                val hideEmptyDaysInAgenda = AppPreferences.hideEmptyDaysInAgenda(context)
+                val agendaItems = AgendaItems(hideEmptyDaysInAgenda).getList(notes, query, idMap)
 
                 dataList = agendaItems.map {
                     when (it) {

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -387,6 +387,7 @@
     <string name="no_states_defined">Keine Status definiert</string>
     <string name="book_name_in_search">Notizbuchname in den Suchergebnissen</string>
     <string name="display_notebook_name">Notizbuchname anzeigen</string>
+    <string name="hide_empty_days_in_agenda">Tage ohne Notizen in Agenda ausblenden</string>
     <string name="display_inherited_tags_in_search_results">Geerbte Schlagwörter in Suchergebnissen</string>
     <string name="display_inherited_tags_in_search_results_summary">Geerbte Schlagwörter in Suchergebnissen anzeigen</string>
     <string name="ongoing_notification">Aktuell</string>

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -331,6 +331,9 @@
     <string name="pref_key_keep_screen_on_menu_item" translatable="false">pref_key_keep_screen_on_menu_item</string>
     <bool name="pref_default_keep_screen_on_menu_item" translatable="false">false</bool>
 
+    <string name="pref_key_hide_empty_days_in_agenda" translatable="false">pref_key_hide_empty_days_in_agenda</string>
+    <bool name="pref_default_hide_empty_days_in_agenda" translatable="false">false</bool>
+
     <string name="pref_key_selected_note_metadata" translatable="false">pref_key_selected_note_metadata</string>
     <string-array name="note_metadata">
         <item>@string/tags</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,6 +458,7 @@
     <string name="book_name_in_search">Notebook name in search results</string>
 
     <string name="display_notebook_name">Display notebook name</string>
+    <string name="hide_empty_days_in_agenda">Hide empty days in agenda</string>
 
     <string name="display_inherited_tags_in_search_results">Inherited tags in search results</string>
     <string name="display_inherited_tags_in_search_results_summary">Display inherited tags in search results</string>

--- a/app/src/main/res/xml/prefs_screen_look_and_feel.xml
+++ b/app/src/main/res/xml/prefs_screen_look_and_feel.xml
@@ -84,4 +84,12 @@
             android:defaultValue="@bool/pref_default_ignore_system_locale"/>
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/agenda">
+
+        <SwitchPreference
+            android:key="@string/pref_key_hide_empty_days_in_agenda"
+            android:title="@string/hide_empty_days_in_agenda"
+            android:defaultValue="@bool/pref_default_hide_empty_days_in_agenda" />
+    </PreferenceCategory>
+
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Original by @mrkuz in https://github.com/orgzly/orgzly-android/pull/871
Resolves: https://github.com/orgzly/orgzly-android/issues/516 (does not add separation characters as some mentioned)

**Before**
<img width="262" alt="The current agenda view of orgzly, with nothing shown for Oct 23" src="https://github.com/orgzly-revived/orgzly-android-revived/assets/21282461/0af27476-3b2b-4f01-82de-af25aa25865c"><img width="262" alt="The current orgzly widget showing the agenda search, with a blank entry for Ot 23" src="https://github.com/orgzly-revived/orgzly-android-revived/assets/21282461/119f8ba3-8e34-4083-908d-c57261ae5b41">


**After**
<img width="262" alt="The updated agenda view, where Oct 23 is skipped and Oct 24 is shown with the note from that day 'Times can have repeater...' " src="https://github.com/orgzly-revived/orgzly-android-revived/assets/21282461/fb9f8879-4db9-4c05-8ad8-597d18a3ae9b"><img width="262" alt="The agenda view widget, showing more info because Oct 23 is skipped" src="https://github.com/orgzly-revived/orgzly-android-revived/assets/21282461/4aa744e3-197f-4a0c-b2d1-29a38e7c1d61">
