### PR TITLE
#7 gradle sha256

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+distributionSha256Sum=e2b82129ab64751fd40437007bd2f7f2afb3c6e41a9198e628650b22d5824a14


### PR DESCRIPTION
Adding the sha256 of the gradle-wrapper.jar file in the gradle/wrapper subdirectory.
This is required for the F-Droid verification of the binary.

I hope this is the right value. :))
I used certutil, as mentioned in #7.
