### PR TITLE
Add auto-sync on suspend

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -1057,6 +1057,12 @@ public class AppPreferences {
                 context.getResources().getBoolean(R.bool.pref_default_auto_sync_on_resume));
     }
 
+    public static boolean syncOnSuspend(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_auto_sync_on_suspend),
+                context.getResources().getBoolean(R.bool.pref_default_auto_sync_on_suspend));
+    }
+
     /*
      * Notes clipboard
      */

--- a/app/src/main/java/com/orgzly/android/sync/AutoSync.kt
+++ b/app/src/main/java/com/orgzly/android/sync/AutoSync.kt
@@ -30,6 +30,11 @@ class AutoSync @Inject constructor(val context: Application, val dataRepository:
                     if (AppPreferences.syncOnResume(context)) {
                         startSync()
                     }
+
+                Type.APP_SUSPENDED ->
+                    if (AppPreferences.syncOnSuspend(context)) {
+                        startSync()
+                    }
             }
         }
     }
@@ -43,7 +48,8 @@ class AutoSync @Inject constructor(val context: Application, val dataRepository:
     enum class Type {
         NOTE_CREATED,
         DATA_MODIFIED,
-        APP_RESUMED
+        APP_RESUMED,
+        APP_SUSPENDED,
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -506,6 +506,13 @@ public class MainActivity extends CommonActivity
     }
 
     @Override
+    protected void onStop() {
+        super.onStop();
+
+        autoSync.trigger(AutoSync.Type.APP_SUSPENDED);
+    }
+
+    @Override
     protected void onDestroy() {
         super.onDestroy();
 

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -253,6 +253,13 @@ public class ShareActivity extends CommonActivity
         }
     }
 
+    @Override
+    protected void onStop() {
+        super.onStop();
+
+        autoSync.trigger(AutoSync.Type.APP_SUSPENDED);
+    }
+
     public static PendingIntent createNewNotePendingIntent(Context context, String category, SavedSearch savedSearch) {
         Intent resultIntent = createNewNoteIntent(context);
 

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -281,6 +281,9 @@
     <string name="pref_key_auto_sync_on_resume" translatable="false">pref_key_auto_sync_on_resume</string>
     <bool name="pref_default_auto_sync_on_resume" translatable="false">false</bool>
 
+    <string name="pref_key_auto_sync_on_suspend" translatable="false">pref_key_auto_sync_on_suspend</string>
+    <bool name="pref_default_auto_sync_on_suspend" translatable="false">false</bool>
+
     <string name="pref_key_auto_sync_on_repo_change" translatable="false">pref_key_auto_sync_on_repo_change</string>
     <bool name="pref_default_auto_sync_on_repo_change" translatable="false">false</bool>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -550,6 +550,9 @@
     <string name="pref_title_on_resume_sync">App started or resumed</string>
     <string name="pref_summary_on_resume_sync">Sync whenever app comes to the foreground</string>
 
+    <string name="pref_title_on_suspend_sync">App suspended</string>
+    <string name="pref_summary_on_suspend_sync">Sync whenever app goes to the background</string>
+
     <string name="pref_title_repo_update_sync">Repositories modified (not implemented yet)</string>
     <string name="pref_summary_repo_update_sync">Sync whenever an update in repositories is detected</string>
 

--- a/app/src/main/res/xml/prefs_screen_auto_sync.xml
+++ b/app/src/main/res/xml/prefs_screen_auto_sync.xml
@@ -36,6 +36,13 @@
         android:defaultValue="@bool/pref_default_auto_sync_on_resume"/>
 
     <SwitchPreference
+        android:key="@string/pref_key_auto_sync_on_suspend"
+        android:dependency="@string/pref_key_auto_sync"
+        android:title="@string/pref_title_on_suspend_sync"
+        android:summary="@string/pref_summary_on_suspend_sync"
+        android:defaultValue="@bool/pref_default_auto_sync_on_suspend"/>
+
+    <SwitchPreference
         android:key="@string/pref_key_auto_sync_on_repo_change"
         android:enabled="false"
         android:title="@string/pref_title_repo_update_sync"


### PR DESCRIPTION
Trigger auto-sync when the app becomes invisible to the user, ex: when navigating away or when locking the device.
This is useful if you don't have `Note updated or deleted` turned on and are using notebooks with multiple users.