### PR TITLE
Set a lower threshold for Git garbage collection

### DIFF
--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -72,6 +72,7 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
         config.setString("remote", prefs.remoteName(), "url", prefs.remoteUri().toString());
         config.setString("user", null, "name", prefs.getAuthor());
         config.setString("user", null, "email", prefs.getEmail());
+        config.setString("gc", null, "auto", "3000");
         config.save();
 
         return new GitRepo(id, git, prefs);


### PR DESCRIPTION
The number refers to the threshold for loose objects in the repo before Git performs housekeeping tasks in connection with common porcelain commands such as "push". The default value is 6700.

This is just intended as a first step towards solving #27 by finding a suitable limit. It should be evaluated by checking regularly how much space can be saved in a repo by running "git gc" manually. If a considerable amount of space can be saved after, say, one month of heavy repo use, then this limit should probably be lowered further.