### PR TITLE
Disable widget opacity on unsupported color scheme

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
@@ -126,6 +126,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
         /* Update preferences which depend on multiple others. */
         updateRemindersScreen()
+        updateWidgetScreen()
     }
 
     private fun setupVersionPreference() {
@@ -326,6 +327,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         }
 
         updateRemindersScreen()
+        updateWidgetScreen()
 
         /* Always notify about possibly changed data, if settings are modified.
          *
@@ -360,6 +362,16 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             preference(R.string.pref_key_snooze_time)?.isEnabled = remindersEnabled
             preference(R.string.pref_key_snooze_type)?.isEnabled = remindersEnabled
             preference(R.string.pref_key_daily_reminder_time)?.isEnabled = remindersEnabled
+        }
+    }
+
+    private fun updateWidgetScreen() {
+        val colorScheme = preference(R.string.pref_key_widget_color_scheme)
+
+        if (colorScheme != null) {
+            /* Widget opacity isn't supported on the dynamic color scheme. */
+            val opacityEnabled = (colorScheme as ListPreference).value != "dynamic"
+            preference(R.string.pref_key_widget_opacity)?.isEnabled = opacityEnabled
         }
     }
 


### PR DESCRIPTION
The dynamic widget color scheme does not support opacity, so inform the user by disabling the setting input.
This was very confusing to me before, until I looked at the code.
![Screenshot_2023-11-04-14-51-51-528_com orgzlyrevived](https://github.com/orgzly-revived/orgzly-android-revived/assets/1911807/20037249-76ad-4ca4-89a1-000bf1349517)
