### PR TITLE
Fix reminder notification settings opening

### DIFF
--- a/app/src/main/res/xml/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml/prefs_screen_reminders.xml
@@ -62,7 +62,7 @@
         android:summary="@string/notification_channel_settings_summary">
         <intent android:action="android.settings.CHANNEL_NOTIFICATION_SETTINGS">
             <extra android:name="android.provider.extra.CHANNEL_ID" android:value="reminders" />
-            <extra android:name="android.provider.extra.APP_PACKAGE" android:value="com.orgzly" />
+            <extra android:name="android.provider.extra.APP_PACKAGE" android:value="com.orgzlyrevived" />
         </intent>
     </androidx.preference.PreferenceScreen>
 


### PR DESCRIPTION
Preference intent to open system notification settings for orgzly in the reminder channel used the previous "com.orgzly" app package instead of "com.orgzlyrevived".