### PR TITLE
Fix/agenda jitter

### DIFF
--- a/app/src/main/java/com/orgzly/android/widgets/ListWidgetFactoryRegistry.kt
+++ b/app/src/main/java/com/orgzly/android/widgets/ListWidgetFactoryRegistry.kt
@@ -1,0 +1,32 @@
+package com.orgzly.android.widgets
+
+import android.widget.RemoteViewsService.RemoteViewsFactory
+import com.orgzly.BuildConfig
+import com.orgzly.android.util.LogUtils
+
+object ListWidgetFactoryRegistry {
+
+    private val factories = mutableMapOf<Long, RemoteViewsFactory>()
+
+    @JvmStatic
+    fun registerFactory(savedSearchId: Long, factory: RemoteViewsFactory) {
+        if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, savedSearchId, factory)
+        factories[savedSearchId] = factory
+    }
+
+    @JvmStatic
+    fun getFactory(savedSearchId: Long): RemoteViewsFactory? {
+        if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, savedSearchId)
+        return factories[savedSearchId]
+    }
+
+    @JvmStatic
+    fun unregisterFactory(savedSearchId: Long) {
+        if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, savedSearchId)
+        factories.remove(savedSearchId)
+    }
+
+
+    private val TAG = ListWidgetFactoryRegistry::class.java.name
+
+}

--- a/app/src/main/java/com/orgzly/android/widgets/ListWidgetService.kt
+++ b/app/src/main/java/com/orgzly/android/widgets/ListWidgetService.kt
@@ -39,8 +39,13 @@ class ListWidgetService : RemoteViewsService() {
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG)
 
         val queryString = intent.getStringExtra(AppIntent.EXTRA_QUERY_STRING).orEmpty()
+        val searchId = intent.getLongExtra(AppIntent.EXTRA_SAVED_SEARCH_ID, -1)
 
-        return ListWidgetViewsFactory(applicationContext, queryString)
+        val factory = ListWidgetViewsFactory(applicationContext, queryString, searchId)
+
+        if (searchId >= 0) ListWidgetFactoryRegistry.registerFactory(searchId, factory)
+
+        return factory
     }
 
     private sealed class WidgetEntry(open val id: Long) {
@@ -56,10 +61,8 @@ class ListWidgetService : RemoteViewsService() {
     }
 
     inner class ListWidgetViewsFactory(
-            val context: Context,
-            private val queryString: String
+        val context: Context, private val queryString: String, private val searchId: Long
     ) : RemoteViewsFactory {
-
         private val query: Query by lazy {
             val parser = InternalQueryParser()
             parser.parse(queryString)
@@ -75,7 +78,7 @@ class ListWidgetService : RemoteViewsService() {
             if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG)
         }
 
-        override fun getLoadingView(): RemoteViews? {
+        override fun getLoadingView(): RemoteViews {
             return RemoteViews(context.packageName, R.layout.item_list_widget_loading)
         }
 
@@ -151,6 +154,7 @@ class ListWidgetService : RemoteViewsService() {
 
         override fun onDestroy() {
             if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG)
+            ListWidgetFactoryRegistry.unregisterFactory(searchId)
         }
 
         private fun setupRemoteViews(views: RemoteViews) {

--- a/app/src/main/java/com/orgzly/android/widgets/ListWidgetService.kt
+++ b/app/src/main/java/com/orgzly/android/widgets/ListWidgetService.kt
@@ -76,7 +76,7 @@ class ListWidgetService : RemoteViewsService() {
         }
 
         override fun getLoadingView(): RemoteViews? {
-            return null
+            return RemoteViews(context.packageName, R.layout.item_list_widget_loading)
         }
 
         override fun getItemId(position: Int): Long {

--- a/app/src/main/res/layout/item_list_widget_loading.xml
+++ b/app/src/main/res/layout/item_list_widget_loading.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/item_list_widget_loading"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:textSize="@dimen/widget_post_title_text_size_14" />
+


### PR DESCRIPTION
The PR focuses on UI stability in the widget, especially when having auto-sync on. 

This is the former state:
https://github.com/orgzly-revived/orgzly-android-revived/assets/1295554/13fb1c91-660d-43f9-b17f-7c3643e7199e

This is the state with the PR applied:
https://github.com/orgzly-revived/orgzly-android-revived/assets/1295554/3b3a036a-37dd-43dd-8df7-7c7b5131de12

The PR implements three changes:


1. An empty loading view is added for list items to prevent the default string flashing during search switches.

2.  The ugly refresh when clicking on the sync button in the widget stems from a bug in the Android `WorkManager`, which triggers a widget update as soon as the last worker finishes (https://issuetracker.google.com/issues/115575872). This is fixed with the workaround Google provides until they fix their bug.

4. Updating the search views with `notifyAppWidgetViewDataChanged` is replaced by manual calls to the update methods to prevent loading the wrong list. This behavior surfaced because of fix 2. Before that an extra refresh of the widget was done, shadowing that the list we are switching away from got updated first. An unnecessary action. The race condition between `notifyAppWidgetViewDataChanged` and `updateAppWidget` was overwhelmingly won by `notifyAppWidgetViewDataChanged` which lead to updating the "old" list. By updating the list we are switching to manually, we can do so, before updating the UI, thus having the correct data even before rendering.
