### PR TITLE
Git sync: Show branch information in namesake status

### DIFF
--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -315,34 +315,39 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
     @Override
     public TwoWaySyncResult syncBook(
             Uri uri, VersionedRook current, File fromDB) throws IOException {
-        boolean onMainBranch = true;
         String fileName = uri.getPath().replaceFirst("^/", "");
+        boolean merged = true;
         if (current != null) {
             RevCommit rookCommit = getCommitFromRevisionString(current.getRevision());
             if (BuildConfig.LOG_DEBUG) {
                 LogUtils.d(TAG, String.format("Syncing file %s, rookCommit: %s", fileName, rookCommit));
             }
-            boolean merged = synchronizer.updateAndCommitFileFromRevisionAndMerge(
+            merged = synchronizer.updateAndCommitFileFromRevisionAndMerge(
                     fromDB, fileName,
                     synchronizer.getFileRevision(fileName, rookCommit),
                     rookCommit);
 
-            // We have attempted a merge. Are we back on the main branch, or still on a temp branch?
-            onMainBranch = git.getRepository().getBranch().equals(preferences.branchName());
-
-            if (merged && !onMainBranch) {
-                onMainBranch = synchronizer.attemptReturnToMainBranch();
+            if (merged) {
+                // Our change was successfully merged. Make an attempt
+                // to return to the main branch, if we are not on it.
+                if (!git.getRepository().getBranch().equals(preferences.branchName())) {
+                    synchronizer.attemptReturnToMainBranch();
+                }
             }
         } else {
             Log.w(TAG, "Unable to find previous commit, loading from repository.");
         }
         File writeBackFile = synchronizer.repoDirectoryFile(fileName);
         return new TwoWaySyncResult(
-                currentVersionedRook(Uri.EMPTY.buildUpon().appendPath(fileName).build()), onMainBranch,
+                currentVersionedRook(Uri.EMPTY.buildUpon().appendPath(fileName).build()), merged,
                 writeBackFile);
     }
 
     public void tryPushIfHeadDiffersFromRemote() {
         synchronizer.tryPushIfHeadDiffersFromRemote();
+    }
+
+    public String getCurrentBranch() throws IOException {
+        return git.getRepository().getBranch();
     }
 }


### PR DESCRIPTION
A slight improvement: Only alert the user when a *new* merge conflict occurs. The rest of the time, the sync status message shows the user if they are not on the main branch, and thus needs to resolve a merge conflict. They can also see clearly when that conflict has been successfully resolved.