### PR TITLE
Git: Further lower the garbage collection threshold

### DIFF
--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -72,7 +72,7 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
         config.setString("remote", prefs.remoteName(), "url", prefs.remoteUri().toString());
         config.setString("user", null, "name", prefs.getAuthor());
         config.setString("user", null, "email", prefs.getEmail());
-        config.setString("gc", null, "auto", "3000");
+        config.setString("gc", null, "auto", "1500");
         config.save();
 
         return new GitRepo(id, git, prefs);


### PR DESCRIPTION
I just noticed that my day-to-day repo could be shrunk from >6 MB to 2.7 MB by running a regular "git gc". This means that more than half of its content was garbage, which should have been collected.

I also confirmed that a recent clone of the repo is much more nippy in Orgzly.

Related to issue #27.