### PR TITLE
Tell Apache MINA SSHD that we are on Android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -194,9 +194,6 @@ dependencies {
     // Git sync via SSH
     implementation "org.eclipse.jgit:org.eclipse.jgit:$versions.jgit"
     implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$versions.jgit"
-    implementation("javax.management:jmx:$versions.javax_management") {
-        because 'Jgit uses ReflectionException'
-    }
     implementation("androidx.security:security-crypto:$versions.security_crypto") {
         because 'SSH key generation'
     }

--- a/app/src/main/java/com/orgzly/android/git/GitSshKeyTransportSetter.kt
+++ b/app/src/main/java/com/orgzly/android/git/GitSshKeyTransportSetter.kt
@@ -3,6 +3,7 @@ package com.orgzly.android.git
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.orgzly.android.App
+import org.apache.sshd.common.util.OsUtils
 import org.eclipse.jgit.annotations.NonNull
 import org.eclipse.jgit.api.TransportCommand
 import org.eclipse.jgit.api.TransportConfigCallback
@@ -52,6 +53,8 @@ class GitSshKeyTransportSetter: GitTransportSetter {
 
         // org.apache.sshd.common.config.keys.IdentityUtils freaks out if user.home is not set
         System.setProperty("user.home", context.filesDir.toString())
+        // org.apache.sshd.common.util.OsUtils has trouble recognizing Android
+        OsUtils.setAndroid(true)
 
         configCallback = TransportConfigCallback { transport: Transport ->
             val sshTransport = transport as SshTransport

--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,6 @@ buildscript {
 
     versions.jgit = '6.7.0.202309050840-r'
 
-    versions.javax_management = '1.2.1'
-
     versions.security_crypto = '1.1.0-alpha03'
 
     versions.biometric_ktx = '1.2.0-alpha04'
@@ -99,11 +97,6 @@ allprojects {
         // For sardine-android
         maven {
             url 'https://jitpack.io'
-        }
-
-        // For javax.management
-        maven {
-            url 'https://www.datanucleus.org/downloads/maven2/'
         }
     }
 


### PR DESCRIPTION
There is code in MINA SSHD which uses the ReflectionException class, which is not present on Android. This code is not supposed to be run on Android, but the OsUtils.isAndroid() check apparently does not work.

Thankfully, there is a setAndroid() method.