### PR TITLE
Disable Git repos on API <24 (Android <7)

### DIFF
--- a/app/src/main/java/com/orgzly/android/git/GitSshKeyTransportSetter.kt
+++ b/app/src/main/java/com/orgzly/android/git/GitSshKeyTransportSetter.kt
@@ -38,7 +38,7 @@ class GitSshKeyTransportSetter: GitTransportSetter {
                 )
             }
 
-            @RequiresApi(Build.VERSION_CODES.M)
+            @RequiresApi(Build.VERSION_CODES.N)
             override fun getDefaultKeys(@NonNull sshDir: File): Iterable<KeyPair>? {
                 return if (SshKey.exists) {
                     listOf(SshKey.getKeyPair())

--- a/app/src/main/java/com/orgzly/android/git/SshKey.kt
+++ b/app/src/main/java/com/orgzly/android/git/SshKey.kt
@@ -69,7 +69,7 @@ object SshKey {
     val exists
         get() = type != null
     private val mustAuthenticate: Boolean
-        @RequiresApi(Build.VERSION_CODES.M)
+        @RequiresApi(Build.VERSION_CODES.N)
         get() {
             return runCatching {
                 if (type !in listOf(Type.KeystoreNative, Type.KeystoreWrappedEd25519)) return false
@@ -128,7 +128,7 @@ object SshKey {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
+    @RequiresApi(Build.VERSION_CODES.N)
     enum class Algorithm(
         val algorithm: String,
         val applyToSpec: KeyGenParameterSpec.Builder.() -> Unit
@@ -217,7 +217,7 @@ object SshKey {
             type = Type.KeystoreWrappedEd25519
         }
 
-    @RequiresApi(Build.VERSION_CODES.M)
+    @RequiresApi(Build.VERSION_CODES.N)
     fun generateKeystoreNativeKey(algorithm: Algorithm, requireAuthentication: Boolean) {
         delete()
 
@@ -248,7 +248,7 @@ object SshKey {
         type = Type.KeystoreNative
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
+    @RequiresApi(Build.VERSION_CODES.N)
     fun getKeyPair(): KeyPair {
         var privateKey: PrivateKey? = null
         var privateKeyLoadAttempts = 0
@@ -348,7 +348,7 @@ object SshKey {
         return KeyPair(publicKey, privateKey)
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
+    @RequiresApi(Build.VERSION_CODES.N)
     fun promptForKeyGeneration() {
         val activity = App.getCurrentActivity()
         if (activity != null) {

--- a/app/src/main/java/com/orgzly/android/ui/SshKeygenActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/SshKeygenActivity.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-@RequiresApi(Build.VERSION_CODES.M)
+@RequiresApi(Build.VERSION_CODES.N)
 private enum class KeyGenType(val generateKey: suspend (requireAuthentication: Boolean) -> Unit) {
     Rsa({ requireAuthentication ->
         SshKey.generateKeystoreNativeKey(SshKey.Algorithm.Rsa, requireAuthentication)
@@ -34,7 +34,7 @@ private enum class KeyGenType(val generateKey: suspend (requireAuthentication: B
     }),
 }
 
-@RequiresApi(Build.VERSION_CODES.M)
+@RequiresApi(Build.VERSION_CODES.N)
 class SshKeygenActivity : CommonActivity() {
 
     private var keyGenType = KeyGenType.Ecdsa
@@ -84,7 +84,7 @@ class SshKeygenActivity : CommonActivity() {
                 }
             }
             val keyguardManager: KeyguardManager = getSystemService(KEYGUARD_SERVICE) as KeyguardManager
-            keyRequireAuthentication.isEnabled = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            keyRequireAuthentication.isEnabled = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
                 false
             } else {
                 keyguardManager.isDeviceSecure

--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
@@ -280,7 +280,7 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
                     return
                 }
                 val repoScheme = getRepoScheme()
-                @RequiresApi(Build.VERSION_CODES.M)
+                @RequiresApi(Build.VERSION_CODES.N)
                 if (repoScheme != "https" && !SshKey.exists) {
                     SshKey.promptForKeyGeneration()
                     return

--- a/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
@@ -100,7 +100,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         }
 
         // Disable Git repos completely on API < 23
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             preference(R.string.pref_key_git_is_enabled)?.let {
                 preferenceScreen.removePreference(it)
             }


### PR DESCRIPTION
The Apache MINA SSHD version which we now rely on uses the Predicate interface, which is not available Android API <24.