### PR TITLE
Removed forced Light theme for splash screen during cold start

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,6 @@
         android:supportsRtl="true"
         android:icon="@mipmap/cic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppLightTheme.Light"
         android:fullBackupContent="@xml/backup_config"
         android:requestLegacyExternalStorage="true">
 


### PR DESCRIPTION
Resolves issue #139.

Android 12 has a new "splash screen" behaviour which uses the application background theming (from Manifest).

The theme was forced to Light theme and it blinded a user with a bright white background, even when dark theme was set in the app, and dark theme was configured system-wide.

By simply removing background configuration in the application Manifest, android 12 now uses the system-wide proper color according to the configured system theme.

There seems to be no side effect on previous android versions (which did not even show this slash screen after all).