### PR TITLE
Log sync times to "major events" log

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,18 +2,18 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
-
 android {
     namespace 'com.orgzly'
 
     compileSdkVersion 32
 
     defaultConfig {
+        def application_id = "com.orgzlyrevived"
         minSdkVersion 21 // Lollipop (5.0)
         targetSdkVersion 32 // Android 12L
-        applicationId "com.orgzlyrevived"
         versionCode 186
         versionName "1.8.15-beta.3"
+        applicationId application_id
 
         testInstrumentationRunner "com.orgzly.android.OrgzlyTestRunner"
         // testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -21,7 +21,10 @@ android {
         multiDexEnabled true
 
         buildConfigField "String", "DROPBOX_APP_KEY", gradle.ext.appProperties.getProperty("dropbox.app_key", '""')
+
         resValue "string", "dropbox_app_key_schema", gradle.ext.appProperties.getProperty("dropbox.app_key_schema", '')
+
+        resValue "string", "application_id", application_id
 
         javaCompileOptions {
             annotationProcessorOptions {
@@ -183,10 +186,8 @@ dependencies {
         exclude group: 'xpp3', module: 'xpp3'
     }
 
-    constraints {
-        implementation('com.squareup.okhttp3:okhttp:4.10.0-RC1') {
-            because 'https://github.com/orgzly/orgzly-android/issues/880'
-        }
+    implementation('com.squareup.okhttp3:okhttp:4.10.0-RC1') {
+        because 'https://github.com/orgzly/orgzly-android/issues/880'
     }
 
     implementation "io.github.rburgst:okhttp-digest:$versions.okhttp_digest"

--- a/app/src/main/java/com/orgzly/android/data/logs/AppLogsRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/logs/AppLogsRepository.kt
@@ -5,5 +5,5 @@ import kotlinx.coroutines.flow.Flow
 interface AppLogsRepository {
     fun log(type: String, str: String)
 
-    fun getFlow(type: String): Flow<List<LogEntry>>
+    fun getFlow(): Flow<List<LogEntry>>
 }

--- a/app/src/main/java/com/orgzly/android/data/logs/DatabaseAppLogsRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/logs/DatabaseAppLogsRepository.kt
@@ -18,8 +18,8 @@ class DatabaseAppLogsRepository @Inject constructor(db: OrgzlyDatabase) : AppLog
         dbAppLog.insert(entry)
     }
 
-    override fun getFlow(type: String): Flow<List<LogEntry>> {
-        return dbAppLog.getFlow(type).map { logEntries ->
+    override fun getFlow(): Flow<List<LogEntry>> {
+        return dbAppLog.getFlow().map { logEntries ->
             logEntries.map { entry ->
                 LogEntry(entry.timestamp, entry.name, entry.message)
             }

--- a/app/src/main/java/com/orgzly/android/db/dao/AppLogDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/AppLogDao.kt
@@ -7,6 +7,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 abstract class AppLogDao : BaseDao<AppLog> {
-    @Query("SELECT * FROM app_logs WHERE name = :name ORDER BY timestamp")
-    abstract fun getFlow(name: String): Flow<List<AppLog>>
+    @Query("SELECT * FROM app_logs ORDER BY timestamp")
+    abstract fun getFlow(): Flow<List<AppLog>>
 }

--- a/app/src/main/java/com/orgzly/android/sync/SyncWorker.kt
+++ b/app/src/main/java/com/orgzly/android/sync/SyncWorker.kt
@@ -9,6 +9,7 @@ import com.orgzly.R
 import com.orgzly.android.App
 import com.orgzly.android.SharingShortcutsManager
 import com.orgzly.android.data.DataRepository
+import com.orgzly.android.data.logs.AppLogsRepository
 import com.orgzly.android.db.entity.BookAction
 import com.orgzly.android.prefs.AppPreferences
 import com.orgzly.android.reminders.RemindersScheduler
@@ -16,6 +17,7 @@ import com.orgzly.android.repos.*
 import com.orgzly.android.ui.notifications.SyncNotifications
 import com.orgzly.android.ui.util.haveNetworkConnection
 import com.orgzly.android.util.AppPermissions
+import com.orgzly.android.util.LogMajorEvents
 import com.orgzly.android.util.LogUtils
 import com.orgzly.android.widgets.ListWidgetProvider
 import kotlinx.coroutines.Dispatchers
@@ -28,6 +30,9 @@ class SyncWorker(val context: Context, val params: WorkerParameters) :
 
     @Inject
     lateinit var dataRepository: DataRepository
+
+    @Inject
+    lateinit var appLogs: AppLogsRepository
 
     override suspend fun doWork(): Result {
         App.appComponent.inject(this)
@@ -84,15 +89,28 @@ class SyncWorker(val context: Context, val params: WorkerParameters) :
 
         checkConditions()?.let { return it }
 
+        val syncStartTime = System.currentTimeMillis()
+
         syncRepos()?.let { return it }
 
         RemindersScheduler.notifyDataSetChanged(App.getAppContext())
         ListWidgetProvider.notifyDataSetChanged(App.getAppContext())
         SharingShortcutsManager().replaceDynamicShortcuts(App.getAppContext())
 
+        val syncEndTime = System.currentTimeMillis()
+
         // Save last successful sync time to preferences
-        val time = System.currentTimeMillis()
-        AppPreferences.lastSuccessfulSyncTime(context, time)
+        AppPreferences.lastSuccessfulSyncTime(context, syncEndTime)
+
+        if (LogMajorEvents.isEnabled()) {
+            val syncDuration = (syncEndTime - syncStartTime)
+            val numberOfRepos = dataRepository.getRepos().size
+            val numberOfBooks = dataRepository.getBooks().size
+            appLogs.log(
+                LogMajorEvents.SYNC,
+                "Sync took $syncDuration milliseconds. Synced $numberOfBooks books in $numberOfRepos repos."
+            )
+        }
 
         return SyncState.getInstance(SyncState.Type.FINISHED)
     }

--- a/app/src/main/java/com/orgzly/android/ui/logs/AppLogsActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/logs/AppLogsActivity.kt
@@ -16,6 +16,7 @@ import com.orgzly.android.ui.util.getAlarmManager
 import com.orgzly.android.ui.util.sharePlainText
 import com.orgzly.android.ui.util.userFriendlyPeriod
 import com.orgzly.databinding.ActivityLogsBinding
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.joda.time.DateTime
 import javax.inject.Inject

--- a/app/src/main/java/com/orgzly/android/ui/logs/AppLogsViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/logs/AppLogsViewModel.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.map
 import java.util.*
 
 class AppLogsViewModel(appLogsRepository: AppLogsRepository) : CommonViewModel() {
-    val logs = appLogsRepository.getFlow(LogMajorEvents.REMINDERS).map {
+    val logs = appLogsRepository.getFlow().map {
         it.map { logEntry ->
             val date = Date(logEntry.time)
             val type = logEntry.type

--- a/app/src/main/java/com/orgzly/android/util/LogMajorEvents.kt
+++ b/app/src/main/java/com/orgzly/android/util/LogMajorEvents.kt
@@ -13,6 +13,7 @@ class LogMajorEvents {
     companion object {
 
         const val REMINDERS = "reminders"
+        const val SYNC = "sync"
 
         fun isEnabled(): Boolean {
             return AppPreferences.logMajorEvents(App.getAppContext())

--- a/app/src/main/res/xml/prefs_screen_developer.xml
+++ b/app/src/main/res/xml/prefs_screen_developer.xml
@@ -21,7 +21,7 @@
         android:title="@string/logs">
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.orgzlyrevived"
+            android:targetPackage="@string/application_id"
             android:targetClass="com.orgzly.android.ui.logs.AppLogsActivity"/>
     </Preference>
 

--- a/app/src/main/res/xml/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml/prefs_screen_reminders.xml
@@ -62,7 +62,7 @@
         android:summary="@string/notification_channel_settings_summary">
         <intent android:action="android.settings.CHANNEL_NOTIFICATION_SETTINGS">
             <extra android:name="android.provider.extra.CHANNEL_ID" android:value="reminders" />
-            <extra android:name="android.provider.extra.APP_PACKAGE" android:value="com.orgzlyrevived" />
+            <extra android:name="android.provider.extra.APP_PACKAGE" android:value="@string/application_id" />
         </intent>
     </androidx.preference.PreferenceScreen>
 

--- a/app/src/main/res/xml/prefs_screen_sync.xml
+++ b/app/src/main/res/xml/prefs_screen_sync.xml
@@ -11,7 +11,7 @@
         android:summary="@string/repos_preference_summary">
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.orgzlyrevived"
+            android:targetPackage="@string/application_id"
             android:targetClass="com.orgzly.android.ui.repos.ReposActivity"/>
     </Preference>
 
@@ -27,7 +27,7 @@
         android:summary="@string/ssh_keygen_preference_summary">
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.orgzlyrevived"
+            android:targetPackage="@string/application_id"
             android:targetClass="com.orgzly.android.ui.SshKeygenActivity"/>
     </Preference>
 

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -12,7 +12,7 @@
         android:shortcutShortLabel="@string/new_note">
         <intent
             android:action="android.intent.action.SEND"
-            android:targetPackage="com.orgzlyrevived"
+            android:targetPackage="@string/application_id"
             android:targetClass="com.orgzly.android.ui.share.ShareActivity" />
     </shortcut>
 
@@ -23,7 +23,7 @@
         android:shortcutShortLabel="@string/sync">
         <intent
             android:action="com.orgzly.intent.action.SYNC_START"
-            android:targetPackage="com.orgzlyrevived"
+            android:targetPackage="@string/application_id"
             android:targetClass="com.orgzly.android.ui.SyncShortcutActivity" />
     </shortcut>
 


### PR DESCRIPTION
This enables easier benchmarking of sync times when testing changes to
the sync logic. I am currently looking at alternative sync workflows for
Git repos, and it's hard to compare sync times just by looking.

Why did I remove the argument to AppLogsRepository.getFlow()? Because I
believe it was a case of over-engineering. There is no way to specify
which type of logs you want to view, and until there is, the only
reasonable behavior is to show all logs.

I have tested this code on my Pixel 5.