### PR TITLE
Change org-java to revived fork, bump to 1.3.1

### DIFF
--- a/.github/workflows/android-build-master.yml
+++ b/.github/workflows/android-build-master.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - 'master'
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
     name: Generate APK
@@ -24,6 +27,8 @@ jobs:
       
       - name: Build APK
         run: ./gradlew assembleDebug
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Upload APK
         uses: actions/upload-artifact@v2

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -35,6 +35,8 @@ jobs:
       # Build the standard version binary.
       - name: Generate "premium" release APK
         run: ./gradlew assemblePremiumRelease --stacktrace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sign APK using key store from repo secrets
         uses: r0adkll/sign-android-release@v1
@@ -56,6 +58,8 @@ jobs:
       # Now do the same for the F-Droid flavor.
       - name: Generate "fdroid" release APK
         run: ./gradlew assembleFdroidRelease --stacktrace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
       - name: Sign APK using key store from repo secrets
         uses: r0adkll/sign-android-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
       # Build the standard version binary.
       - name: Generate "premium" release APK
         run: ./gradlew assemblePremiumRelease --stacktrace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sign APK using key store from repo secrets
         uses: r0adkll/sign-android-release@v1
@@ -57,6 +59,8 @@ jobs:
       # Now do the same for the F-Droid flavor.
       - name: Generate "fdroid" release APK
         run: ./gradlew assembleFdroidRelease --stacktrace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
       - name: Sign APK using key store from repo secrets
         uses: r0adkll/sign-android-release@v1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -216,7 +216,7 @@ def orgJavaLocation() {
         logger.info("app: Using org-java from ${gradle.ext.orgJavaDir}")
         return project(':org-java')
     } else {
-        logger.info("app: Using com.orgzly:org-java:$versions.org_java from Maven repository")
-        return "com.orgzly:org-java:$versions.org_java"
+        logger.info("app: Using com.orgzlyrevived:org-java:$versions.org_java from Maven repository")
+        return "com.orgzlyrevived:org-java:$versions.org_java"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
 
     versions.android_test_uiautomator = '2.2.0'
 
-    versions.org_java = '1.3-SNAPSHOT'
+    versions.org_java = '1.3.1'
 
     versions.loremipsum = '1.0'
 
@@ -97,6 +97,16 @@ allprojects {
         // For sardine-android
         maven {
             url 'https://jitpack.io'
+        }
+
+        // For  com.orgzlyrevived.org-java
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/orgzly-revived/org-java")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,8 +104,8 @@ allprojects {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/orgzly-revived/org-java")
             credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key")  ?: System.getenv("GITHUB_TOKEN")
             }
         }
     }

--- a/sample.app.properties
+++ b/sample.app.properties
@@ -15,6 +15,13 @@ dropbox.app_key = "appkey"
 # Same as above, but prefixed with "db-"
 dropbox.app_key_schema = "db-appkey"
 
+
+# Github Package Registry access credentials.
+# see https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry
+# used to pull the com.orgzlyrevived.org-java dependency from https://github.com/orgzly-revived/org-java
+gpr.user = ""
+gpr.key  = ""
+
 # Use org-java from local directory instead of the Maven repository.
 # If you are working on org-java project, this can make development process easier.
 # Don't forget to sync project with Gradle files (in Android Studio) if you change this value.


### PR DESCRIPTION
- Instead of the `com.orgzly:org-java` dependency from central, now use the `com.orgzlyrevived:org-java` for from this organization's maven registry 
- Bump version from `1.3-SNAPSHOT` to `1.3.1`, which is the latest (and only) revived release (contains the fix for #95)

