### PR TITLE
Various fixes for Git repos

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,11 +192,13 @@ dependencies {
 
     implementation "io.github.rburgst:okhttp-digest:$versions.okhttp_digest"
 
-    // Git sync over SSH
-    implementation "org.eclipse.jgit:org.eclipse.jgit:$versions.jgit"
+    implementation("org.eclipse.jgit:org.eclipse.jgit:$versions.jgit") {
+        because 'Git repo support'
+    }
     implementation("org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$versions.jgit") {
-        // Resolves DuplicatePlatformClasses lint error
-        exclude group: 'org.apache.sshd', module: 'sshd-osgi'
+        because 'SSH transport support for Git repos'
+        // Avoid DuplicatePlatformClasses error:
+        exclude group: 'org.apache.sshd', module: 'sshd-sftp'
     }
     implementation("androidx.security:security-crypto:$versions.security_crypto") {
         because 'SSH key generation'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,16 +192,18 @@ dependencies {
 
     implementation "io.github.rburgst:okhttp-digest:$versions.okhttp_digest"
 
-    // Git sync via SSH
+    // Git sync over SSH
     implementation "org.eclipse.jgit:org.eclipse.jgit:$versions.jgit"
-    implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$versions.jgit"
+    implementation("org.eclipse.jgit:org.eclipse.jgit.ssh.apache:$versions.jgit") {
+        // Resolves DuplicatePlatformClasses lint error
+        exclude group: 'org.apache.sshd', module: 'sshd-osgi'
+    }
     implementation("androidx.security:security-crypto:$versions.security_crypto") {
         because 'SSH key generation'
     }
     implementation("androidx.biometric:biometric-ktx:$versions.biometric_ktx") {
         because 'Protect SSH key with biometric prompt'
     }
-
 }
 
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-kapt'
 android {
     namespace 'com.orgzly'
 
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
         def application_id = "com.orgzlyrevived"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -47,6 +47,7 @@
 
 -dontwarn org.joda.convert.**
 
+-dontwarn org.eclipse.jgit.**
 -dontwarn com.jcraft.**
 -dontwarn org.slf4j.**
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28" />
+        android:maxSdkVersion="29" />
 
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 

--- a/app/src/main/java/com/orgzly/android/git/GitSshKeyTransportSetter.kt
+++ b/app/src/main/java/com/orgzly/android/git/GitSshKeyTransportSetter.kt
@@ -3,7 +3,6 @@ package com.orgzly.android.git
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.orgzly.android.App
-import org.apache.sshd.common.util.OsUtils
 import org.eclipse.jgit.annotations.NonNull
 import org.eclipse.jgit.api.TransportCommand
 import org.eclipse.jgit.api.TransportConfigCallback
@@ -53,8 +52,6 @@ class GitSshKeyTransportSetter: GitTransportSetter {
 
         // org.apache.sshd.common.config.keys.IdentityUtils freaks out if user.home is not set
         System.setProperty("user.home", context.filesDir.toString())
-        // org.apache.sshd.common.util.OsUtils has trouble recognizing Android
-        OsUtils.setAndroid(true)
 
         configCallback = TransportConfigCallback { transport: Transport ->
             val sshTransport = transport as SshTransport

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -158,7 +158,6 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
             } catch (IOException ex) {
                 ex.printStackTrace();
             }
-            Log.e(TAG, "JGit error:", e);
             throw new IOException(e);
         }
     }

--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
@@ -525,10 +525,6 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
         override fun endTask() {
 
         }
-
-        override fun showDuration(enabled: Boolean) {
-            TODO("Not yet implemented")
-        }
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
@@ -125,10 +125,14 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
             createDefaultRepoFolder()
             binding.activityRepoGitAuthor.setText("Orgzly")
             binding.activityRepoGitBranch.setText(R.string.git_default_branch)
-            val userDeviceName: String = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.S) {
-                Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
-            } else {
-                Settings.Secure.getString(contentResolver, "bluetooth_name")
+            val userDeviceName: String = try {
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.S) {
+                    Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
+                } else {
+                    Settings.Secure.getString(contentResolver, "bluetooth_name")
+                }
+            } catch (e: Exception) {
+                "MyPhone"
             }
             binding.activityRepoGitEmail.setText(String.format("orgzly@%s", userDeviceName))
         }

--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
@@ -3,6 +3,7 @@ package com.orgzly.android.ui.repo.git
 
 import android.app.Activity
 import android.app.ProgressDialog
+import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
@@ -21,6 +22,7 @@ import android.widget.EditText
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
 import com.orgzly.R
 import com.orgzly.android.App
@@ -38,15 +40,14 @@ import com.orgzly.android.ui.repo.BrowserActivity
 import com.orgzly.android.ui.repo.RepoViewModel
 import com.orgzly.android.ui.repo.RepoViewModelFactory
 import com.orgzly.android.ui.showSnackbar
+import com.orgzly.android.ui.util.copyPlainTextToClipboard
 import com.orgzly.android.util.AppPermissions
 import com.orgzly.android.util.MiscUtils
 import com.orgzly.databinding.ActivityRepoGitBinding
-import org.eclipse.jgit.errors.TransportException
 import org.eclipse.jgit.errors.NoRemoteRepositoryException
 import org.eclipse.jgit.errors.NotSupportedException
 import org.eclipse.jgit.lib.ProgressMonitor
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.IOException
 
 class GitRepoActivity : CommonActivity(), GitPreferences {
@@ -275,8 +276,14 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
                 save()
             } else {
                 val targetDirectory = File(binding.activityRepoGitDirectory.text.toString())
+                if (!targetDirectory.exists()) {
+                    binding.activityRepoGitDirectoryLayout.error =
+                        getString(R.string.git_clone_error_invalid_target_dir)
+                    return
+                }
                 if (targetDirectory.list()!!.isNotEmpty()) {
-                    binding.activityRepoGitDirectoryLayout.error = getString(R.string.git_clone_error_target_not_empty)
+                    binding.activityRepoGitDirectoryLayout.error =
+                        getString(R.string.git_clone_error_target_not_empty)
                     return
                 }
                 val repoScheme = getRepoScheme()
@@ -295,28 +302,28 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
         if (e == null) {
             save()
         } else {
-            val error = when (e.cause) {
-                is NoRemoteRepositoryException -> R.string.git_clone_error_invalid_repo
-                is TransportException -> {
-                    // JGit's catch-all "remote hung up unexpectedly" message is not very useful.
-                    if (Regex("hung up unexpectedly").containsMatchIn(e.cause!!.message!!)) {
-                        String.format(getString(R.string.git_clone_error_ssh), e.cause!!.cause!!.message)
-                    } else {
-                        String.format(getString(R.string.git_clone_error_ssh), e.cause!!.message)
-                    }
+            val error = when (val rootException = getRootException(e)) {
+                is NoRemoteRepositoryException -> getString(R.string.git_clone_error_invalid_repo)
+                is NotSupportedException -> getString(R.string.git_clone_error_uri_not_supported)
+                else -> rootException.localizedMessage?.toString()
+            }
+            MaterialAlertDialogBuilder(this)
+                .setPositiveButton(R.string.ok, null)
+                .setNeutralButton("Copy stack trace") { _: DialogInterface?, _: Int ->
+                    this.copyPlainTextToClipboard("Error during cloning", e.stackTraceToString())
                 }
-                // TODO: This should be checked when the user enters a directory by hand
-                is FileNotFoundException -> R.string.git_clone_error_invalid_target_dir
-                is GitRepo.DirectoryNotEmpty -> R.string.git_clone_error_target_not_empty
-                is NotSupportedException -> R.string.git_clone_error_uri_not_supported
-                else -> R.string.git_clone_error_unknown
-            }
-            when (error) {
-                is Int -> { showSnackbar(error) }
-                is String -> { showSnackbar(error) }
-            }
-            e.printStackTrace()
+                .setMessage(error)
+                .show()
+            Log.e(TAG, "Error during repo cloning:", e)
         }
+    }
+
+    private fun getRootException(e: Throwable): Throwable {
+        var result = e
+        while (result.cause != null) {
+            result = result.cause as Throwable
+        }
+        return result
     }
 
     private fun saveToPreferences(id: Long): Boolean {
@@ -355,7 +362,7 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
 
         for (field in fields) {
             if (field.layout.visibility == View.GONE || field.allowEmpty) {
-                continue;
+                continue
             }
             if (errorIfEmpty(field.editText, field.layout)) {
                 hasEmptyFields = true
@@ -472,10 +479,8 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
             try {
                 GitRepo.ensureRepositoryExists(fragment, true, this)
             } catch (e: IOException) {
-                Log.e(TAG, "Error while cloning Git repository:", e)
                 return e
             }
-
             return null
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ buildscript {
 
     versions.okhttp_digest = '2.7'
 
-    versions.jgit = '6.7.0.202309050840-r'
+    versions.jgit = '5.13.1.202206130422-r'
 
     versions.security_crypto = '1.1.0-alpha03'
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ buildscript {
 
     versions.okhttp_digest = '2.7'
 
-    versions.jgit = '5.13.1.202206130422-r'
+    versions.jgit = '5.13.3.202401111512-r'
 
     versions.security_crypto = '1.1.0-alpha03'
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ buildscript {
 
     versions.jgit = '5.13.3.202401111512-r'
 
-    versions.security_crypto = '1.1.0-alpha03'
+    versions.security_crypto = '1.1.0-alpha06'
 
     versions.biometric_ktx = '1.2.0-alpha04'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,6 @@ android.enableJetifier = true
 android.databinding.incremental = true
 
 kotlin.code.style = official
+org.gradle.unsafe.configuration-cache=true
 
 # org.gradle.warning.mode=all


### PR DESCRIPTION
The biggest change here is that we are reverting back from JGit v6 to v5. It turned out that v6 relies on classes which are only present in the very latest Android versions, so we excluded too many devices when we switched to v6. I'll take that as a lesson to test on more API versions next time...

The commit messages should explain the various changes, otherwise I'm happy to update them with clarifications.

I'm willing to break this into separate PRs, if someone prefers that.

I have verified that the following works with this branch on Android 10 through 12:
- create new device
- add fingerprint device lock
- install minified release APK
- create Ed25519 SSH key (the most error-prone type)
  - protected by device lock (except on Android 10, which gives a message saying the API does not support it)
- add and clone Git repo
- sync changes in both directions