### PR TITLE
Don't use a variable for application_id in build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,12 +8,13 @@ android {
     compileSdkVersion 32
 
     defaultConfig {
-        def application_id = "com.orgzlyrevived"
         minSdkVersion 21 // Lollipop (5.0)
         targetSdkVersion 32 // Android 12L
         versionCode 188
         versionName "1.8.15"
-        applicationId application_id
+        applicationId = "com.orgzlyrevived"
+        resValue "string", "application_id", "com.orgzlyrevived"
+
 
         testInstrumentationRunner "com.orgzly.android.OrgzlyTestRunner"
         // testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -23,8 +24,6 @@ android {
         buildConfigField "String", "DROPBOX_APP_KEY", gradle.ext.appProperties.getProperty("dropbox.app_key", '""')
 
         resValue "string", "dropbox_app_key_schema", gradle.ext.appProperties.getProperty("dropbox.app_key_schema", '')
-
-        resValue "string", "application_id", application_id
 
         javaCompileOptions {
             annotationProcessorOptions {


### PR DESCRIPTION
I thought I was being clever, but it breaks the Fdroid build pipeline - thanks @stefan2904 for pointing that out.

This partly reverts 14cdfc5be.