### PR TITLE
Fetch our fork of org-java from jitpack.io

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,7 @@ android {
 }
 
 dependencies {
-    implementation orgJavaLocation()
+    implementation "com.github.orgzly-revived:org-java:$versions.org_java"
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.kotlin_coroutines")
 
@@ -206,18 +206,4 @@ dependencies {
 
 repositories {
     mavenCentral()
-}
-
-/*
- * If "orgJavaDir" property is set, load org-java as a module. If property is not set,
- * use org-java from Maven repository. See settings.gradle.
- */
-def orgJavaLocation() {
-    if (gradle.ext.has('orgJavaDir')) {
-        logger.info("app: Using org-java from ${gradle.ext.orgJavaDir}")
-        return project(':org-java')
-    } else {
-        logger.info("app: Using com.orgzlyrevived:org-java:$versions.org_java from Maven repository")
-        return "com.orgzlyrevived:org-java:$versions.org_java"
-    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,7 @@ android {
 }
 
 dependencies {
-    implementation "com.github.orgzly-revived:org-java:$versions.org_java"
+    implementation orgJavaLocation()
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.kotlin_coroutines")
 
@@ -206,4 +206,18 @@ dependencies {
 
 repositories {
     mavenCentral()
+}
+
+/*
+ * If "orgJavaDir" property is set, load org-java as a module. If property is not set,
+ * use org-java from Maven repository. See settings.gradle.
+ */
+def orgJavaLocation() {
+    if (gradle.ext.has('orgJavaDir')) {
+        logger.info("app: Using org-java from ${gradle.ext.orgJavaDir}")
+        return project(':org-java')
+    } else {
+        logger.info("app: Using com.github.orgzly-revived:org-java:$versions.org_java from Maven repository")
+        return "com.github.orgzly-revived:org-java:$versions.org_java"
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
 
     versions.android_test_uiautomator = '2.2.0'
 
-    versions.org_java = '1.3.1'
+    versions.org_java = 'v1.3.2'
 
     versions.loremipsum = '1.0'
 
@@ -94,19 +94,9 @@ allprojects {
             url 'https://oss.sonatype.org/content/repositories/snapshots'
         }
 
-        // For sardine-android
+        // For sardine-android and org-java
         maven {
             url 'https://jitpack.io'
-        }
-
-        // For  com.orgzlyrevived.org-java
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/orgzly-revived/org-java")
-            credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-                password = project.findProperty("gpr.key")  ?: System.getenv("GITHUB_TOKEN")
-            }
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,19 +18,4 @@ def loadAppProperties() {
 
 gradle.ext.appProperties = loadAppProperties()
 
-// Setup org-java project if "org_java" is set to an existing directory.
-if (gradle.ext.appProperties.org_java_directory?.trim()) {
-    def path = gradle.ext.appProperties.org_java_directory
-
-    def dir = path.startsWith('/') ? new File(path) : new File(settingsDir, path)
-
-    if (dir.exists()) {
-        include ':org-java'
-        project(':org-java').projectDir = dir
-        gradle.ext.orgJavaDir = dir
-    } else {
-        logger.warn("Ignoring non-existent directory $dir")
-    }
-}
-
 include ':app'

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,4 +18,19 @@ def loadAppProperties() {
 
 gradle.ext.appProperties = loadAppProperties()
 
+// Setup org-java project if "org_java" is set to an existing directory.
+if (gradle.ext.appProperties.org_java_directory?.trim()) {
+    def path = gradle.ext.appProperties.org_java_directory
+
+    def dir = path.startsWith('/') ? new File(path) : new File(settingsDir, path)
+
+    if (dir.exists()) {
+        include ':org-java'
+        project(':org-java').projectDir = dir
+        gradle.ext.orgJavaDir = dir
+    } else {
+        logger.warn("Ignoring non-existent directory $dir")
+    }
+}
+
 include ':app'


### PR DESCRIPTION
For background, see the discussion here: https://github.com/orgzly-revived/orgzly-android-revived/pull/154#issuecomment-1935937147.

This is easier than managing our own Maven package, and Fdroid is supposed to trust Jitpack.io.

Thanks @stefan2904 for bringing this up!