### PR TITLE
Git: Check .orgzlyignore when writing files

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -766,6 +766,7 @@
     <string name="error_generate_ssh_key">Error while trying to generate the SSH key pair</string>
     <string name="ssh_key_error_dialog_text">Message: \n</string>
     <string name="ssh_key_locked_and_no_activity">Error: SSH key can only be unlocked from an activity</string>
+    <string name="error_file_matches_repo_ignore_rule">Repository filename matches a rule in %s</string>
 
     <!-- Sync status -->
     <string name="sync_status_no_change">No change</string>

--- a/app/src/main/res/values/strings_untranslatable.xml
+++ b/app/src/main/res/values/strings_untranslatable.xml
@@ -42,6 +42,7 @@
     <string name="git_default_branch" translatable="false">master</string>
     <string name="certificates_hint">-----BEGIN CERTIFICATE-----</string>
     <string name="webdav" translatable="false">WebDAV</string>
+    <string name="repo_ignore_rules_file" translatable="false">.orgzlyignore</string>
 
     <string name="lorem_ipsum" translatable="false">Lorem ipsum dolor sit amet, consectetur</string>
     <string name="lorem_ipsum_rich" translatable="false">Lorem *ipsum* dolor sit amet, /consectetur/</string>


### PR DESCRIPTION
Until now, repo ignore rules have only been checked during getBooks(). This adds checks during storeBook() and renameBook().

This resolves #190.