### PR TITLE
Dropbox repos: Use the new "refresh token" OAuth flow

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
         debug {
             buildConfigField "boolean", "LOG_DEBUG", "true"
 
-            buildConfigField "String", "DROPBOX_TOKEN", gradle.ext.appProperties.getProperty("dropbox.token", '""')
+            buildConfigField "String", "DROPBOX_REFRESH_TOKEN", gradle.ext.appProperties.getProperty("dropbox.refresh_token", '""')
         }
     }
 

--- a/app/src/androidTest/java/com/orgzly/android/repos/DropboxRepoTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/repos/DropboxRepoTest.java
@@ -7,6 +7,7 @@ import com.orgzly.android.db.entity.BookView;
 import com.orgzly.android.prefs.AppPreferences;
 import com.orgzly.android.util.MiscUtils;
 
+import org.json.JSONObject;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +27,12 @@ public class DropboxRepoTest extends OrgzlyTest {
         super.setUp();
         Assume.assumeTrue(BuildConfig.IS_DROPBOX_ENABLED);
 
-        AppPreferences.dropboxToken(context, BuildConfig.DROPBOX_TOKEN);
+        JSONObject mockSerializedDbxCredential = new JSONObject();
+        mockSerializedDbxCredential.put("access_token", "dummy");
+        mockSerializedDbxCredential.put("expires_at", System.currentTimeMillis());
+        mockSerializedDbxCredential.put("refresh_token", BuildConfig.DROPBOX_REFRESH_TOKEN);
+        mockSerializedDbxCredential.put("app_key", BuildConfig.DROPBOX_APP_KEY);
+        AppPreferences.dropboxSerializedCredential(context, mockSerializedDbxCredential.toString());
     }
 
     @Test

--- a/app/src/androidTest/java/com/orgzly/android/repos/SyncTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/repos/SyncTest.java
@@ -2,7 +2,6 @@ package com.orgzly.android.repos;
 
 import android.net.Uri;
 
-import com.orgzly.BuildConfig;
 import com.orgzly.android.BookName;
 import com.orgzly.android.LocalStorage;
 import com.orgzly.android.OrgzlyTest;
@@ -10,7 +9,6 @@ import com.orgzly.android.db.entity.Book;
 import com.orgzly.android.db.entity.BookView;
 import com.orgzly.android.db.entity.NoteView;
 import com.orgzly.android.db.entity.Repo;
-import com.orgzly.android.prefs.AppPreferences;
 import com.orgzly.android.sync.BookNamesake;
 import com.orgzly.android.sync.BookSyncStatus;
 import com.orgzly.android.util.EncodingDetect;
@@ -38,8 +36,6 @@ public class SyncTest extends OrgzlyTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-
-        AppPreferences.dropboxToken(context, BuildConfig.DROPBOX_TOKEN);
     }
 
     @Test

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -892,13 +892,13 @@ public class AppPreferences {
      * Dropbox token.
      */
 
-    public static String dropboxToken(Context context) {
-        String key = context.getResources().getString(R.string.pref_key_dropbox_token);
+    public static String dropboxSerializedCredential(Context context) {
+        String key = context.getResources().getString(R.string.pref_key_dropbox_credential);
         return getStateSharedPreferences(context).getString(key, null);
     }
 
-    public static void dropboxToken(Context context, String value) {
-        String key = context.getResources().getString(R.string.pref_key_dropbox_token);
+    public static void dropboxSerializedCredential(Context context, String value) {
+        String key = context.getResources().getString(R.string.pref_key_dropbox_credential);
         SharedPreferences.Editor editor = getStateSharedPreferences(context).edit();
         if (value == null) {
             editor.remove(key);

--- a/app/src/main/java/com/orgzly/android/ui/repo/dropbox/DropboxRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/dropbox/DropboxRepoActivity.kt
@@ -1,13 +1,11 @@
 package com.orgzly.android.ui.repo.dropbox
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.text.TextUtils
-import android.widget.EditText
 import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
 import androidx.lifecycle.Observer
@@ -58,11 +56,6 @@ class DropboxRepoActivity : CommonActivity() {
             } else {
                 toggleLink()
             }
-        }
-
-        binding.activityRepoDropboxLinkButton.setOnLongClickListener {
-            editAccessToken()
-            true
         }
 
         // Not working when done in XML
@@ -123,47 +116,6 @@ class DropboxRepoActivity : CommonActivity() {
         binding.fab.setOnClickListener {
             saveAndFinish()
         }
-    }
-
-    private fun editAccessToken() {
-        @SuppressLint("InflateParams")
-        val view = layoutInflater.inflate(R.layout.dialog_simple_one_liner, null, false)
-
-        val editView = view.findViewById<EditText>(R.id.dialog_input).apply {
-            setSelectAllOnFocus(true)
-
-            setHint(R.string.access_token)
-
-            client.token?.let {
-                setText(it)
-            }
-        }
-
-        alertDialog = MaterialAlertDialogBuilder(this)
-                .setView(view)
-                .setTitle(R.string.access_token)
-                .setPositiveButton(R.string.set) { _, _ ->
-                    editView.text.toString().let { value ->
-                        if (TextUtils.isEmpty(value)) {
-                            client.unlink()
-                        } else {
-                            client.setToken(value)
-                        }
-                    }
-                    updateDropboxLinkUnlinkButton()
-                }
-                .setNeutralButton(R.string.clear) { _, _ ->
-                    client.unlink()
-                    updateDropboxLinkUnlinkButton()
-                }
-                .setNegativeButton(R.string.cancel) { _, _ -> }
-                .create().apply {
-                    setOnShowListener {
-                        KeyboardUtils.openSoftKeyboard(editView)
-                    }
-
-                    show()
-                }
     }
 
     public override fun onResume() {

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -591,7 +591,7 @@
     <string name="pref_key_clear_database" translatable="false">pref_key_clear_database</string>
 
     <!-- State-type preferences, not changeable by user. They have no defaults. -->
-    <string name="pref_key_dropbox_token" translatable="false">pref_key_dropbox_token</string>
+    <string name="pref_key_dropbox_credential" translatable="false">pref_key_dropbox_token</string>
     <string name="pref_key_is_getting_started_notebook_loaded" translatable="false">pref_key_is_getting_started_notebook_loaded</string>
     <string name="pref_key_last_used_version_code" translatable="false">pref_key_last_used_version_code</string>
     <string name="pref_key_last_successful_sync_time" translatable="false">pref_key_last_successful_sync_time</string>


### PR DESCRIPTION
As indicated here: https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/Java-SDK-issues-with-short-lived-token/m-p/508693/highlight/true#M25109.

- Store the DbxCredential object in JSON form in app preferences.
- Store requestConfig as a property, since it is now needed in many places.
- Write a mock credential to preferences when preparing for Dropbox-related tests.
- Remove unused updating of Dropbox token in SyncTest.
- Clean up some unused imports.

All tests in the "repos" directory (and all other tests) are now passing. Before this change, the access token used by Orgzly would expire within a few hours, since only short-lived tokens are now handed out when using the old OAuth flow.