### PR TITLE
Build F-Droid APK without Dropbox app key

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -32,13 +32,31 @@ jobs:
           echo "BUILD_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
           echo Last build tool version is: $BUILD_TOOL_VERSION
 
+      - name: Generate "fdroid" release APK
+        run: ./gradlew assembleFdroidRelease --stacktrace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign APK using key store from repo secrets
+        uses: r0adkll/sign-android-release@v1
+        id: sign_fdroid_apk
+        with:
+          releaseDirectory: app/build/outputs/apk/fdroid/release
+          signingKeyBase64: ${{ secrets.APK_SIGNING_KEYSTORE_FILE }}
+          alias: orgzly-revived-20231013
+          keyStorePassword: ${{ secrets.APK_SIGNING_KEYSTORE_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
+
+      - name: Rename APK file
+        run: mv ${{steps.sign_fdroid_apk.outputs.signedReleaseFile}} orgzly-revived-fdroid-${{ env.VERSION }}.apk
+
       - name: Add Dropbox app identifier
         shell: bash
         run: |
           echo "dropbox.app_key = \"${{ secrets.DROPBOX_APP_KEY }}\"" >> app.properties
           echo "dropbox.app_key_schema = \"db-${{ secrets.DROPBOX_APP_KEY }}\"" >> app.properties
-        
-      # Build the standard version binary.
+
       - name: Generate "premium" release APK
         run: ./gradlew assemblePremiumRelease --stacktrace
         env:
@@ -61,27 +79,6 @@ jobs:
       - name: Rename APK file
         run: mv ${{steps.sign_apk.outputs.signedReleaseFile}} orgzly-revived-${{ env.VERSION }}.apk
 
-      # Now do the same for the F-Droid flavor.
-      - name: Generate "fdroid" release APK
-        run: ./gradlew assembleFdroidRelease --stacktrace
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-      - name: Sign APK using key store from repo secrets
-        uses: r0adkll/sign-android-release@v1
-        id: sign_fdroid_apk
-        with:
-          releaseDirectory: app/build/outputs/apk/fdroid/release
-          signingKeyBase64: ${{ secrets.APK_SIGNING_KEYSTORE_FILE }}
-          alias: orgzly-revived-20231013
-          keyStorePassword: ${{ secrets.APK_SIGNING_KEYSTORE_PASSWORD }}
-        env:
-          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
-
-      - name: Rename APK file
-        run: mv ${{steps.sign_fdroid_apk.outputs.signedReleaseFile}} orgzly-revived-fdroid-${{ env.VERSION }}.apk
-
-      # Now upload all the binaries and create a release
       - name: Upload APK and create Github pre-release draft
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,31 @@ jobs:
           echo "BUILD_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
           echo Last build tool version is: $BUILD_TOOL_VERSION
 
+      - name: Generate "fdroid" release APK
+        run: ./gradlew assembleFdroidRelease --stacktrace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+      - name: Sign APK using key store from repo secrets
+        uses: r0adkll/sign-android-release@v1
+        id: sign_fdroid_apk
+        with:
+          releaseDirectory: app/build/outputs/apk/fdroid/release
+          signingKeyBase64: ${{ secrets.APK_SIGNING_KEYSTORE_FILE }}
+          alias: orgzly-revived-20231013
+          keyStorePassword: ${{ secrets.APK_SIGNING_KEYSTORE_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
+
+      - name: Rename APK file
+        run: mv ${{steps.sign_fdroid_apk.outputs.signedReleaseFile}} orgzly-revived-fdroid-${{ env.VERSION }}.apk
+
       - name: Add Dropbox app identifier
         shell: bash
         run: |
           echo "dropbox.app_key = \"${{ secrets.DROPBOX_APP_KEY }}\"" >> app.properties
           echo "dropbox.app_key_schema = \"db-${{ secrets.DROPBOX_APP_KEY }}\"" >> app.properties
-        
-      # Build the standard version binary.
+
       - name: Generate "premium" release APK
         run: ./gradlew assemblePremiumRelease --stacktrace
         env:
@@ -62,27 +80,6 @@ jobs:
       - name: Rename APK file
         run: mv ${{steps.sign_apk.outputs.signedReleaseFile}} orgzly-revived-${{ env.VERSION }}.apk
 
-      # Now do the same for the F-Droid flavor.
-      - name: Generate "fdroid" release APK
-        run: ./gradlew assembleFdroidRelease --stacktrace
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-      - name: Sign APK using key store from repo secrets
-        uses: r0adkll/sign-android-release@v1
-        id: sign_fdroid_apk
-        with:
-          releaseDirectory: app/build/outputs/apk/fdroid/release
-          signingKeyBase64: ${{ secrets.APK_SIGNING_KEYSTORE_FILE }}
-          alias: orgzly-revived-20231013
-          keyStorePassword: ${{ secrets.APK_SIGNING_KEYSTORE_PASSWORD }}
-        env:
-          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
-
-      - name: Rename APK file
-        run: mv ${{steps.sign_fdroid_apk.outputs.signedReleaseFile}} orgzly-revived-fdroid-${{ env.VERSION }}.apk
-
-      # Now upload all the binaries and create a release
       - name: Upload APK and create Github release draft
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
           echo "BUILD_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
           echo Last build tool version is: $BUILD_TOOL_VERSION
 
+      - name: Get version name from git tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
       - name: Generate "fdroid" release APK
         run: ./gradlew assembleFdroidRelease --stacktrace
         env:
@@ -73,9 +76,6 @@ jobs:
           keyStorePassword: ${{ secrets.APK_SIGNING_KEYSTORE_PASSWORD }}
         env:
           BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
-
-      - name: Get version name from git tag
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
       - name: Rename APK file
         run: mv ${{steps.sign_apk.outputs.signedReleaseFile}} orgzly-revived-${{ env.VERSION }}.apk

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 21 // Lollipop (5.0)
         targetSdkVersion 32 // Android 12L
-        versionCode 201
-        versionName "1.8.20"
+        versionCode 202
+        versionName "1.8.21"
         applicationId = "com.orgzlyrevived"
         resValue "string", "application_id", "com.orgzlyrevived"
 

--- a/app/src/main/res/layout/dialog_whats_new.xml
+++ b/app/src/main/res/layout/dialog_whats_new.xml
@@ -22,6 +22,15 @@
 
         <TextView
             style="@style/WhatsNewVersion"
+            android:text="v1.8.21"
+            tools:ignore="HardcodedText" />
+
+        <com.orgzly.android.ui.views.WhatsNewChange
+            style="@style/WhatsNewChange"
+            app:text="Fix F-Droid build not being reproducible" />
+
+        <TextView
+            style="@style/WhatsNewVersion"
             android:text="v1.8.20"
             tools:ignore="HardcodedText" />
 

--- a/metadata/en-US/changelogs/202.txt
+++ b/metadata/en-US/changelogs/202.txt
@@ -1,0 +1,1 @@
+• Fix F-Droid build not being reproducible


### PR DESCRIPTION
Resolves #233.

I changed the order so that we first build the F-Droid APK, then set the Dropbox app key, then build the "premium" APK.

Review is kind of pointless, because I have already triggered a new release build in order to resolve the problem for F-Droid. But I'll keep this PR open for a while, so there is a chance someone notices it.