### PR TITLE
Target API 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21 // Lollipop (5.0)
-        targetSdkVersion 32 // Android 12L
+        targetSdkVersion 33 // Android 12L
         versionCode 202
         versionName "1.8.21"
         applicationId = "com.orgzlyrevived"


### PR DESCRIPTION
So that we can publish in the Play store. "New apps must target Android 13 (API level 33) or higher".