### PR TITLE
Enable "sync failed" notifications by default

### DIFF
--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -317,7 +317,7 @@
     <string name="pref_key_reminders_notification_settings_V26" translatable="false">pref_key_reminders_notification_settings_v26</string>
 
     <string name="pref_key_show_sync_notifications" translatable="false">pref_key_show_sync_notifications</string>
-    <bool name="pref_default_show_sync_notifications" translatable="false">false</bool>
+    <bool name="pref_default_show_sync_notifications" translatable="false">true</bool>
 
     <string name="pref_key_note_metadata_folded" translatable="false">pref_key_note_metadata_folded</string>
     <bool name="pref_default_note_metadata_folded" translatable="false">false</bool>


### PR DESCRIPTION
These notifications have been off by default since they were added ages ago, but I don't see why they should. If something goes wrong during syncing, the least surprising behavior should be to fire off a notification.