### PR TITLE
Enable "sync failed" notifications by default

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/ShareActivityTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ShareActivityTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.orgzly.R
@@ -92,6 +93,8 @@ class ShareActivityTest : OrgzlyTest() {
 
         onView(withId(R.id.location_button)).perform(scroll(), click())
         onView(withText("book-two")).perform(click())
+        SystemClock.sleep(100)
+        onView(isRoot()).perform(waitId(R.id.location_button, 5000))
         onView(withId(R.id.location_button)).check(matches(withText("book-two")))
 
         scenario.onActivity { activity ->

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -317,7 +317,7 @@
     <string name="pref_key_reminders_notification_settings_V26" translatable="false">pref_key_reminders_notification_settings_v26</string>
 
     <string name="pref_key_show_sync_notifications" translatable="false">pref_key_show_sync_notifications</string>
-    <bool name="pref_default_show_sync_notifications" translatable="false">false</bool>
+    <bool name="pref_default_show_sync_notifications" translatable="false">true</bool>
 
     <string name="pref_key_note_metadata_folded" translatable="false">pref_key_note_metadata_folded</string>
     <bool name="pref_default_note_metadata_folded" translatable="false">false</bool>


### PR DESCRIPTION
These notifications have been off by default since they were first added ages ago, and I'm thinking maybe the person who added them was just being cautious. I always turn these on. If something goes wrong during syncing, the least surprising behavior for a new user should be to fire off a notification.