### PR TITLE
 Ensure the "alarms & reminders" permission is granted before syncing

### DIFF
--- a/app/src/main/java/com/orgzly/android/sync/SyncState.kt
+++ b/app/src/main/java/com/orgzly/android/sync/SyncState.kt
@@ -24,6 +24,7 @@ data class SyncState(val type: Type, val message: String? = null, val current: I
         FAILED_NO_CONNECTION,
         FAILED_NO_STORAGE_PERMISSION,
         FAILED_NO_BOOKS_FOUND,
+        FAILED_NO_ALARMS_PERMISSION,
         FAILED_EXCEPTION
     }
 
@@ -33,6 +34,7 @@ data class SyncState(val type: Type, val message: String? = null, val current: I
             Type.FAILED_NO_CONNECTION,
             Type.FAILED_NO_STORAGE_PERMISSION,
             Type.FAILED_NO_BOOKS_FOUND,
+            Type.FAILED_NO_ALARMS_PERMISSION,
             Type.FAILED_EXCEPTION ->
                 true
             else ->
@@ -83,6 +85,7 @@ data class SyncState(val type: Type, val message: String? = null, val current: I
                 Type.FAILED_NO_REPOS -> getString(R.string.no_repos)
                 Type.FAILED_NO_CONNECTION -> getString(R.string.no_connection)
                 Type.FAILED_NO_STORAGE_PERMISSION -> getString(R.string.storage_permissions_missing)
+                Type.FAILED_NO_ALARMS_PERMISSION -> getString(R.string.alarms_permissions_missing)
                 Type.FAILED_NO_BOOKS_FOUND -> getString(R.string.no_books)
                 Type.FAILED_EXCEPTION -> message
             }

--- a/app/src/main/java/com/orgzly/android/ui/CommonFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/CommonFragment.kt
@@ -69,6 +69,7 @@ open class CommonFragment : Fragment() {
             FAILED_NO_REPOS,
             FAILED_NO_CONNECTION,
             FAILED_NO_STORAGE_PERMISSION,
+            FAILED_NO_ALARMS_PERMISSION,
             FAILED_NO_BOOKS_FOUND,
             FAILED_EXCEPTION ->
                 progressIndicator.visibility = View.GONE

--- a/app/src/main/java/com/orgzly/android/ui/sync/SyncFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/sync/SyncFragment.kt
@@ -204,6 +204,7 @@ class SyncFragment : Fragment() {
                 SyncState.Type.FAILED_NO_REPOS,
                 SyncState.Type.FAILED_NO_CONNECTION,
                 SyncState.Type.FAILED_NO_STORAGE_PERMISSION,
+                SyncState.Type.FAILED_NO_ALARMS_PERMISSION,
                 SyncState.Type.FAILED_NO_BOOKS_FOUND,
                 SyncState.Type.FAILED_EXCEPTION -> {
                     setAnimation(false)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,6 +593,7 @@
     </plurals>
 
     <string name="storage_permissions_missing">No storage permission</string>
+    <string name="alarms_permissions_missing">No permission to set reminders</string>
     <string name="file_does_not_exist">File does not exist: %s</string>
 
     <string name="import_from">Import from “%1$s”?</string>


### PR DESCRIPTION
Without this, the first sync after installing the app leads to a SecurityException and app crash on API >= 33.