### PR TITLE
Further lower the Git auto gc threshold

### DIFF
--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -77,7 +77,7 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
         config.setString("remote", prefs.remoteName(), "url", prefs.remoteUri().toString());
         config.setString("user", null, "name", prefs.getAuthor());
         config.setString("user", null, "email", prefs.getEmail());
-        config.setString("gc", null, "auto", "1500");
+        config.setString("gc", null, "auto", "256");
         config.save();
 
         return new GitRepo(id, git, prefs);


### PR DESCRIPTION
It seems that JGit on Android is significantly slowed down by even small amounts of loose objects. I have long been aware that syncing Git repos tends to be snappy right after cloning, but then take longer and longer. I recently performed "git gc" on my main Orgzly repo, which was syncing very slowly. Its size went down from 9 MB to 3 MB, which may sound little, but the sync time dropped by almost 90%!

See https://stackoverflow.com/a/16342938 for an explanation of how the threshold value works.