### PR TITLE
Fixes the image loading

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
@@ -1,5 +1,6 @@
 package com.orgzly.android.espresso
 
+import android.os.Build
 import android.os.Environment
 import android.os.SystemClock
 import androidx.test.core.app.ActivityScenario
@@ -28,9 +29,11 @@ class ExternalLinksTest(private val param: Parameter) : OrgzlyTest() {
     data class Parameter(val link: String, val check: () -> Any)
 
     @get:Rule
-    val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
-        android.Manifest.permission.READ_MEDIA_IMAGES
-    )
+    val grantPermissionRule: GrantPermissionRule = if (Build.VERSION.SDK_INT >= 33) {
+        GrantPermissionRule.grant(android.Manifest.permission.READ_MEDIA_IMAGES)
+    } else {
+        GrantPermissionRule.grant()
+    }
 
     companion object {
         @JvmStatic

--- a/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.rule.GrantPermissionRule
 import com.orgzly.R
 import com.orgzly.android.App
 import com.orgzly.android.OrgzlyTest
@@ -15,6 +16,7 @@ import com.orgzly.android.espresso.util.EspressoUtils.onNoteInBook
 import com.orgzly.android.espresso.util.EspressoUtils.onSnackbar
 import com.orgzly.android.ui.main.MainActivity
 import org.hamcrest.Matchers.startsWith
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -24,6 +26,11 @@ import org.junit.runners.Parameterized
 class ExternalLinksTest(private val param: Parameter) : OrgzlyTest() {
 
     data class Parameter(val link: String, val check: () -> Any)
+
+    @get:Rule
+    val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        android.Manifest.permission.READ_MEDIA_IMAGES
+    )
 
     companion object {
         @JvmStatic

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 

--- a/app/src/main/java/com/orgzly/android/util/AppPermissions.kt
+++ b/app/src/main/java/com/orgzly/android/util/AppPermissions.kt
@@ -70,7 +70,10 @@ object AppPermissions {
             Usage.BOOK_EXPORT -> Manifest.permission.WRITE_EXTERNAL_STORAGE
             Usage.SYNC_START -> Manifest.permission.WRITE_EXTERNAL_STORAGE
             Usage.SAVED_SEARCHES_EXPORT_IMPORT -> Manifest.permission.WRITE_EXTERNAL_STORAGE
-            Usage.EXTERNAL_FILES_ACCESS -> Manifest.permission.READ_EXTERNAL_STORAGE
+            Usage.EXTERNAL_FILES_ACCESS -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                Manifest.permission.READ_MEDIA_IMAGES
+            else
+                Manifest.permission.READ_EXTERNAL_STORAGE
             Usage.POST_NOTIFICATIONS -> Manifest.permission.POST_NOTIFICATIONS
         }
     }


### PR DESCRIPTION
It was just a case of requesting the correct permission for Android sdk level 33 and above.

This partially fixes, #278 but it file urls for other things are still limited and for Google's sake we would have to start doing remote syncing to private files, because Google diskikes the idea of people sharing files.