### PR TITLE
Revert recent (post v1.8.28) upgrades of some important dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,11 @@ buildscript {
 
     versions.android_gradle_plugin = '8.7.1'
 
-    versions.kotlin = '2.0.21'
+    versions.kotlin = '1.9.23'
 
     versions.kotlin_coroutines = '1.7.3'
 
-    versions.jetbrains_annotations = '26.0.1'
+    versions.jetbrains_annotations = '24.1.0'
 
     versions.android_multidex = '2.0.1'
 
@@ -29,7 +29,7 @@ buildscript {
 
     versions.android_room = '2.6.1'
 
-    versions.android_lifecycle = '2.8.6'
+    versions.android_lifecycle = '2.8.5'
 
     versions.android_workmanager = '2.9.1'
 


### PR DESCRIPTION
I introduced too many bugs in v1.8.28. I want to solve them before upgrading more key dependencies.

This reverts commit b876d39578b9238fdaa6a504c8fbd3908bb10781. This reverts commit 1a13777ce5b0b5c7847a4c35d9434258589c1585. This reverts commit b6de4d466d13dc0c8e9ae022e2072ed101de3065. This reverts commit 9d28fc50bf3502af3b9ec844ff8e4c7f89e7f577.