### PR TITLE
Truncate DocumentFile before writing to it

### DIFF
--- a/app/src/main/java/com/orgzly/android/repos/DocumentRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DocumentRepo.java
@@ -194,7 +194,7 @@ public class DocumentRepo implements SyncRepo {
             }
         }
 
-        try (OutputStream out = context.getContentResolver().openOutputStream(destinationFile.getUri())) {
+        try (OutputStream out = context.getContentResolver().openOutputStream(destinationFile.getUri(), "wt")) {
             MiscUtils.writeFileToStream(file, out);
         }
 


### PR DESCRIPTION
Before 43d88fd, this was not needed, because the file was always deleted and re-created first.

This should resolve issues #385 and #395.