### PR TITLE
Revert "Update dependency com.github.thegrizzlylabs:sardine-android t…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ buildscript {
 
     versions.glide = '4.16.0'
 
-    versions.sardine = '0.9'
+    versions.sardine = '0.8'
 
     versions.okhttp_digest = '2.7'
 


### PR DESCRIPTION
…o v0.9"

This reverts commit 94441a146b61730d4f92b8483af4cff9b5e432e8.

The reason is issue #403 -- users have reported problems with 403 errors since this change.