### PR TITLE
Feat/customize notification led color

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -329,6 +329,12 @@ public class AppPreferences {
                 context.getResources().getBoolean(R.bool.pref_default_reminders_led));
     }
 
+    public static String remindersLedColor(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_reminders_led_color),
+                context.getResources().getString(R.string.pref_default_reminders_led_color));
+    }
+
     public static boolean remindersVibrate(Context context) {
         return getDefaultSharedPreferences(context).getBoolean(
                 context.getResources().getString(R.string.pref_key_reminders_vibrate),

--- a/app/src/main/java/com/orgzly/android/reminders/RemindersNotifications.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/RemindersNotifications.kt
@@ -26,7 +26,8 @@ import com.orgzly.android.util.UserTimeFormatter
 object RemindersNotifications {
     val VIBRATION_PATTERN = longArrayOf(500, 50, 50, 300)
 
-    private val LIGHTS = Triple(Color.BLUE, 1000, 5000)
+    private val LIGHTS_ON_MS = 1000
+    private val LIGHTS_OFF_MS = 5000
 
     fun showNotifications(context: Context, notes: List<NoteReminder>, logs: AppLogsRepository) {
         val notificationManager = context.getNotificationManager()
@@ -38,7 +39,8 @@ object RemindersNotifications {
 
             val content = getContent(context, noteReminder)
 
-            val builder = NotificationCompat.Builder(context, NotificationChannels.REMINDERS)
+            val builder = NotificationCompat.Builder(context,
+                NotificationChannels.channelIdForReminders())
                     .setAutoCancel(true)
                     .setCategory(NotificationCompat.CATEGORY_REMINDER)
                     .setPriority(NotificationCompat.PRIORITY_MAX)
@@ -61,7 +63,9 @@ object RemindersNotifications {
 
             // Set LED
             if (AppPreferences.remindersLed(context)) {
-                builder.setLights(LIGHTS.first, LIGHTS.second, LIGHTS.third)
+                val colorString = AppPreferences.remindersLedColor(context);
+                val color = Color.parseColor(colorString);
+                builder.setLights(color, LIGHTS_ON_MS, LIGHTS_OFF_MS)
             }
 
             builder.setContentTitle(OrgFormatter.parse(
@@ -127,7 +131,8 @@ object RemindersNotifications {
         // Create a group summary notification, but only if notifications can be grouped
         if (canGroupReminders()) {
             if (notes.isNotEmpty()) {
-                val builder = NotificationCompat.Builder(context, NotificationChannels.REMINDERS)
+                val builder = NotificationCompat.Builder(context,
+                    NotificationChannels.channelIdForReminders())
                         .setAutoCancel(true)
                         .setSmallIcon(R.drawable.cic_logo_for_notification)
                         .setGroup(Notifications.REMINDERS_GROUP)

--- a/app/src/main/java/com/orgzly/android/ui/notifications/Notifications.java
+++ b/app/src/main/java/com/orgzly/android/ui/notifications/Notifications.java
@@ -57,7 +57,7 @@ public class Notifications {
         PendingIntent newNotePendingIntent =
                 ShareActivity.createNewNotePendingIntent(context, "ongoing notification", null);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NotificationChannels.ONGOING)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NotificationChannels.channelIdForOngoing())
                 .setOngoing(true)
                 .setSmallIcon(R.drawable.cic_logo_for_notification)
                 .setContentTitle(context.getString(R.string.new_note))

--- a/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
@@ -6,6 +6,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
+import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.preference.*
 import com.orgzly.BuildConfig
@@ -26,6 +27,7 @@ import com.orgzly.android.usecase.UseCase
 import com.orgzly.android.util.AppPermissions
 import com.orgzly.android.util.LogUtils
 import com.orgzly.android.widgets.ListWidgetProvider
+import com.orgzly.android.NotificationChannels
 
 /**
  * Displays settings.
@@ -121,6 +123,18 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
                 }
             } else {
                 preferenceScreen.removePreference(it)
+            }
+        }
+
+        preference(R.string.pref_key_reminders_led_color)?.let {
+            it.setOnPreferenceChangeListener {
+              _, newValue ->
+                val pattern = Regex("^#[0-9A-Fa-f]{6}$")
+                val stringCorrect = pattern.matches(newValue.toString())
+                if (!stringCorrect) {
+                    Toast.makeText(activity, "Please enter a hexadecimal value for color.", Toast.LENGTH_SHORT).show()
+                } 
+                stringCorrect
             }
         }
 
@@ -369,6 +383,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
         updateRemindersScreen()
         updateWidgetScreen()
+        updateNotificationChannels()
 
         /* Always notify about possibly changed data, if settings are modified.
          *
@@ -379,6 +394,11 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         RemindersScheduler.notifyDataSetChanged(requireContext())
         ListWidgetProvider.notifyDataSetChanged(requireContext())
         SharingShortcutsManager().replaceDynamicShortcuts(requireContext())
+    }
+
+    private fun updateNotificationChannels() {
+        var context = requireContext();
+        NotificationChannels.updateAll(context);
     }
 
     private fun updateRemindersScreen() {
@@ -403,6 +423,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             preference(R.string.pref_key_snooze_time)?.isEnabled = remindersEnabled
             preference(R.string.pref_key_snooze_type)?.isEnabled = remindersEnabled
             preference(R.string.pref_key_daily_reminder_time)?.isEnabled = remindersEnabled
+            preference(R.string.pref_key_reminders_led_color)?.isEnabled = remindersEnabled
         }
     }
 

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -259,6 +259,9 @@
 
     <string name="pref_key_reminders_led" translatable="false">pref_key_reminders_led</string>
     <bool name="pref_default_reminders_led" translatable="false">true</bool>
+    
+    <string name="pref_key_reminders_led_color" translatable="false">pref_key_reminders_led_color</string>
+    <string name="pref_default_reminders_led_color" translatable="false">#0000FF</string>
 
     <string name="pref_key_daily_reminder_time" translatable="false">pref_key_daily_reminder_time</string>
     <!-- Time in minutes after midnight. 540 minutes == 9 o'clock -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,6 +490,8 @@
     <string name="pref_title_reminders_sound">Sound</string>
     <string name="pref_title_reminders_vibrate">Vibration</string>
     <string name="pref_title_reminders_led">Light</string>
+    <string name="pref_title_reminders_led_color">LED color</string>
+    <string name="pref_summary_reminders_led_color">Set the color of the LED. Has no effect on existing notifications.</string>
 
     <string name="pref_title_snooze_time">Snooze time (minutes)</string>
     <string name="pref_title_snooze_type">Snooze type</string>

--- a/app/src/main/res/xml/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml/prefs_screen_reminders.xml
@@ -42,7 +42,7 @@
             android:key="@string/pref_key_reminders_sound"
             android:title="@string/pref_title_reminders_sound"
             android:defaultValue="@bool/pref_default_reminders_sound" />
-
+    
         <SwitchPreference
             android:key="@string/pref_key_reminders_led"
             android:title="@string/pref_title_reminders_led"
@@ -55,6 +55,12 @@
     </PreferenceCategory>
 
     <!-- v26 and after -->
+    <EditTextPreference
+            android:defaultValue="@string/pref_default_reminders_led_color"
+            android:key="pref_key_reminders_led_color"
+            android:title="@string/pref_title_reminders_led_color"
+            android:summary="@string/pref_summary_reminders_led_color"/>
+
     <!-- Open system settings to configure reminders' notification channel -->
     <androidx.preference.PreferenceScreen
         android:key="@string/pref_key_reminders_notification_settings_V26"


### PR DESCRIPTION
This PR provides a solution for setting custom LED colors for notifications.
Default value is set to blue to avoid any changes for existing users.
To reduce dependencies to external libraries, the color can only be defined as hex-value string not by any other sophisticated color-chooser widget.

First Kotlin PR, so please feel free to point out even slight issues. Thanks.