### PR TITLE
Add Git commit hash info to developer settings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,8 @@ android {
 
             buildConfigField "boolean", "LOG_DEBUG", "false"
 
+            buildConfigField "String", "GIT_COMMIT", "\"${getCheckedOutGitCommitHash()}\""
+
             // signingConfig signingConfigs.debug
         }
 
@@ -61,6 +63,8 @@ android {
             buildConfigField "boolean", "LOG_DEBUG", "true"
 
             buildConfigField "String", "DROPBOX_REFRESH_TOKEN", gradle.ext.appProperties.getProperty("dropbox.refresh_token", '""')
+
+            buildConfigField "String", "GIT_COMMIT", "\"${getCheckedOutGitCommitHash()}\""
         }
     }
 
@@ -227,4 +231,23 @@ def orgJavaLocation() {
         logger.info("app: Using com.github.orgzly-revived:org-java:$versions.org_java from Maven repository")
         return "com.github.orgzly-revived:org-java:$versions.org_java"
     }
+}
+
+// https://gist.github.com/JonasGroeger/7620911
+def getCheckedOutGitCommitHash() {
+    def gitFolder = "$projectDir/../.git/"
+    def takeFromHash = 12
+    /*
+     * '.git/HEAD' contains either
+     *      in case of detached head: the currently checked out commit hash
+     *      otherwise: a reference to a file containing the current commit hash
+     */
+    def head = new File(gitFolder + "HEAD").text.split(":") // .git/HEAD
+    def isCommit = head.length == 1 // e5a7c79edabbf7dd39888442df081b1c9d8e88fd
+    // def isRef = head.length > 1     // ref: refs/heads/master
+
+    if(isCommit) return head[0].trim().take(takeFromHash) // e5a7c79edabb
+
+    def refHead = new File(gitFolder + head[1].trim()) // .git/refs/heads/master
+    refHead.text.trim().take takeFromHash
 }

--- a/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
@@ -79,6 +79,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
         setupVersionPreference()
 
+        setupGitCommitPreference()
+
         setDefaultStateForNewNote()
 
         preference(R.string.pref_key_file_absolute_root)?.let {
@@ -153,6 +155,12 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
                 listener?.onWhatsNewDisplayRequest()
                 true
             }
+        }
+    }
+
+    private fun setupGitCommitPreference() {
+        preference(R.string.pref_key_git_commit)?.let { pref ->
+            pref.summary = BuildConfig.GIT_COMMIT
         }
     }
 

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -594,6 +594,7 @@
     <string name="pref_key_ssh_keygen" translatable="false">pref_key_ssh_keygen</string>
     <string name="pref_key_ssh_show_public_key" translatable="false">pref_key_ssh_show_public_key</string>
     <string name="pref_key_version" translatable="false">pref_key_version</string>
+    <string name="pref_key_git_commit" translatable="false">pref_key_git_commit</string>
     <string name="pref_key_reload_getting_started" translatable="false">pref_key_reload_getting_started</string>
     <string name="pref_key_clear_database" translatable="false">pref_key_clear_database</string>
 

--- a/app/src/main/res/xml/prefs_screen_developer.xml
+++ b/app/src/main/res/xml/prefs_screen_developer.xml
@@ -2,6 +2,7 @@
 
 <androidx.preference.PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/developer_options">
 
     <SwitchPreference
@@ -24,5 +25,10 @@
             android:targetPackage="@string/application_id"
             android:targetClass="com.orgzly.android.ui.logs.AppLogsActivity"/>
     </Preference>
+
+    <Preference
+        android:key="pref_key_git_commit"
+        android:title="Git commit of app build"
+        app:enableCopying="true" />
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
I find this useful when running a test build on my phone, if I forget which branch my build comes from.