### PR TITLE
Add reminder alarm feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,9 +22,9 @@
 
     <!-- For reminders -->
     <uses-permission android:name="android.permission.VIBRATE"/>
-
-    <!-- For reminders -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:name=".android.App"
@@ -170,6 +170,9 @@
             android:name=".android.widgets.ListWidgetService"
             android:permission="android.permission.BIND_REMOTEVIEWS"
             android:exported="false" />
+
+        <service
+            android:name=".android.reminders.AlarmSoundService" />
 
         <activity
             android:name=".android.widgets.ListWidgetSelectionActivity"

--- a/app/src/main/java/com/orgzly/android/ActionReceiver.kt
+++ b/app/src/main/java/com/orgzly/android/ActionReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import com.orgzly.android.AppIntent.ACTION_SYNC_START
 import com.orgzly.android.AppIntent.ACTION_SYNC_STOP
 import com.orgzly.android.sync.SyncRunner
+import com.orgzly.android.reminders.AlarmSoundService
 
 class ActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, receivedIntent: Intent) {

--- a/app/src/main/java/com/orgzly/android/NotificationBroadcastReceiver.kt
+++ b/app/src/main/java/com/orgzly/android/NotificationBroadcastReceiver.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import com.orgzly.BuildConfig
 import com.orgzly.android.data.logs.AppLogsRepository
 import com.orgzly.android.reminders.RemindersScheduler
+import com.orgzly.android.reminders.AlarmSoundService
 import com.orgzly.android.ui.notifications.Notifications
 import com.orgzly.android.ui.util.getNotificationManager
 import com.orgzly.android.usecase.NoteUpdateStateDone
@@ -57,6 +58,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
         val id = intent.getIntExtra(AppIntent.EXTRA_NOTIFICATION_ID, 0)
 
         if (id > 0) {
+            context.stopService(Intent(context, AlarmSoundService::class.java))
             context.getNotificationManager().let {
                 it.cancel(tag, id)
                 cancelRemindersSummary(it)

--- a/app/src/main/java/com/orgzly/android/db/dao/ReminderTimeDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/ReminderTimeDao.kt
@@ -11,6 +11,7 @@ interface ReminderTimeDao {
             var bookName: String,
             var state: String?,
             var title: String,
+            var tags: String?,
             var timeType: Int,
             var orgTimestampString: String)
 
@@ -21,6 +22,7 @@ interface ReminderTimeDao {
         coalesce(b.title, b.name) as bookName,
         n.state as state,
         n.title as title,
+        n.tags as tags,
         $SCHEDULED_TIME as timeType,
         t.string as orgTimestampString
         FROM org_ranges r
@@ -37,6 +39,7 @@ interface ReminderTimeDao {
         coalesce(b.title, b.name) as bookName,
         n.state as state,
         n.title as title,
+        n.tags as tags,
         $DEADLINE_TIME as timeType,
         t.string as orgTimestampString
         FROM org_ranges r
@@ -53,6 +56,7 @@ interface ReminderTimeDao {
         coalesce(b.title, b.name) as bookName,
         n.state as state,
         n.title as title,
+        n.tags as tags,
         $EVENT_TIME as timeType,
         t.string as orgTimestampString
         FROM note_events e

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -13,10 +13,12 @@ import com.orgzly.R;
 import com.orgzly.android.App;
 import com.orgzly.android.LocalStorage;
 import com.orgzly.org.OrgStatesWorkflow;
+import com.orgzly.org.datetime.OrgDateTime;
 
 import org.eclipse.jgit.transport.URIish;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.joda.time.DateTime;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -323,6 +325,18 @@ public class AppPreferences {
                 context.getResources().getBoolean(R.bool.pref_default_reminders_sound));
     }
 
+    public static boolean remindersAlarm(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_reminders_alarm),
+                context.getResources().getBoolean(R.bool.pref_default_reminders_alarm));
+    }
+
+    public static String remindersAlarmTags(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_reminders_alarm_tags),
+                context.getResources().getString(R.string.pref_default_reminders_alarm_tags));
+    }
+
     public static boolean remindersLed(Context context) {
         return getDefaultSharedPreferences(context).getBoolean(
                 context.getResources().getString(R.string.pref_key_reminders_led),
@@ -357,6 +371,14 @@ public class AppPreferences {
         String key = context.getResources().getString(R.string.pref_key_daily_reminder_time);
         return getDefaultSharedPreferences(context).getInt(key,
                 context.getResources().getInteger(R.integer.pref_default_daily_reminder_time));
+    }
+
+    public static DateTime reminderDailyTimeAsDateTime(Context context) {
+        int reminderTime = reminderDailyTime(context);
+        int hours = reminderTime / 60;
+        int minutes = reminderTime % 60;
+        OrgDateTime dt = new OrgDateTime.Builder(new OrgDateTime(false)).setHour(hours).setMinute(minutes).setHasTime(true).build();
+        return new DateTime(dt.getCalendar());
     }
 
     public static void reminderDailyTime(Context context, int value) {

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -13,12 +13,10 @@ import com.orgzly.R;
 import com.orgzly.android.App;
 import com.orgzly.android.LocalStorage;
 import com.orgzly.org.OrgStatesWorkflow;
-import com.orgzly.org.datetime.OrgDateTime;
 
 import org.eclipse.jgit.transport.URIish;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.joda.time.DateTime;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -371,14 +369,6 @@ public class AppPreferences {
         String key = context.getResources().getString(R.string.pref_key_daily_reminder_time);
         return getDefaultSharedPreferences(context).getInt(key,
                 context.getResources().getInteger(R.integer.pref_default_daily_reminder_time));
-    }
-
-    public static DateTime reminderDailyTimeAsDateTime(Context context) {
-        int reminderTime = reminderDailyTime(context);
-        int hours = reminderTime / 60;
-        int minutes = reminderTime % 60;
-        OrgDateTime dt = new OrgDateTime.Builder(new OrgDateTime(false)).setHour(hours).setMinute(minutes).setHasTime(true).build();
-        return new DateTime(dt.getCalendar());
     }
 
     public static void reminderDailyTime(Context context, int value) {

--- a/app/src/main/java/com/orgzly/android/reminders/AlarmSoundService.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/AlarmSoundService.kt
@@ -1,0 +1,64 @@
+package com.orgzly.android.reminders
+
+import android.app.Service
+import android.content.Intent
+import android.content.Context
+import android.media.MediaPlayer
+import android.media.RingtoneManager
+import android.media.AudioManager
+import android.media.Ringtone
+import android.media.AudioAttributes
+import android.os.IBinder
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import com.orgzly.android.ui.util.getAudioManager
+
+class AlarmSoundService : Service() {
+    private var player: MediaPlayer? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+
+        // ensure no silent/vibration mode
+        var audioManager = applicationContext.getAudioManager()
+        if (audioManager.getRingerMode() == AudioManager.RINGER_MODE_NORMAL) {
+
+            // get alarm sound
+            val uri = Settings.System.DEFAULT_ALARM_ALERT_URI ?: Settings.System.DEFAULT_RINGTONE_URI
+            uri?.let {
+
+                // create alarm volume media player
+                player = MediaPlayer()
+                player?.setAudioAttributes(
+                        AudioAttributes.Builder()
+                        .setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED)
+                        .setLegacyStreamType(AudioManager.STREAM_ALARM)
+                        .setUsage(AudioAttributes.USAGE_ALARM)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .build()
+                )
+                player?.setDataSource(this@AlarmSoundService, it)
+                player?.setWakeMode(applicationContext, PowerManager.PARTIAL_WAKE_LOCK)
+                player?.setLooping(true)
+                player?.prepare()
+                player?.start()
+            }
+        }
+
+        return START_REDELIVER_INTENT
+    }
+
+    override fun onDestroy() {
+
+        // stop audio
+        player?.stop()
+        player?.release()
+        player = null
+
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+}

--- a/app/src/main/java/com/orgzly/android/reminders/AlarmSoundService.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/AlarmSoundService.kt
@@ -19,6 +19,11 @@ class AlarmSoundService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
 
+        // ensure no other active alarm
+        if (player != null) {
+            return START_REDELIVER_INTENT
+        }
+        
         // ensure no silent/vibration mode
         var audioManager = applicationContext.getAudioManager()
         if (audioManager.getRingerMode() == AudioManager.RINGER_MODE_NORMAL) {

--- a/app/src/main/java/com/orgzly/android/reminders/NoteReminderPayload.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/NoteReminderPayload.kt
@@ -7,6 +7,7 @@ data class NoteReminderPayload(
     var bookId: Long,
     var bookName: String,
     var title: String,
+    var tags: String?,
     var timeType: Int,
     var orgDateTime: OrgDateTime
 )

--- a/app/src/main/java/com/orgzly/android/reminders/NoteReminders.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/NoteReminders.kt
@@ -69,6 +69,7 @@ object NoteReminders {
                         noteTime.bookId,
                         noteTime.bookName,
                         noteTime.title,
+                        noteTime.tags,
                         noteTime.timeType,
                         orgDateTime)
 

--- a/app/src/main/java/com/orgzly/android/reminders/RemindersBroadcastReceiver.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/RemindersBroadcastReceiver.kt
@@ -203,6 +203,7 @@ class RemindersBroadcastReceiver : BroadcastReceiver() {
                     noteTime.bookId,
                     noteTime.bookName,
                     noteTime.title,
+                    noteTime.tags,
                     noteTime.timeType,
                     orgDateTime)
 

--- a/app/src/main/java/com/orgzly/android/reminders/RemindersNotifications.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/RemindersNotifications.kt
@@ -69,12 +69,9 @@ object RemindersNotifications {
                 val alarmTags = AppPreferences.remindersAlarmTags(context).split(' ')
                 if (alarmTags.isEmpty() || noteTags.any { tag -> alarmTags.contains(tag) }) {
 
-                    // ignore daily reminder time
-                    // TODO this results in the notification not playing an alarm when the user
-                    // schedules it on the exact time as the daily reminder. to still play the alarm in this case,
-                    // we can check if the date of the note matches the daily reminder time
-                    val dailyTime = AppPreferences.reminderDailyTimeAsDateTime(context)
-                    if (!noteReminder.runTime.equals(dailyTime)) {
+                    // ring alarm for all notifications with a time attached
+                    // this does not include daily reminders as they do not trigger for notes with a time set
+                    if (noteReminder.payload.orgDateTime.hasTime()) {
 
                         // start alarm sound
                         context.startService(Intent(context, AlarmSoundService::class.java))

--- a/app/src/main/java/com/orgzly/android/reminders/RemindersNotifications.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/RemindersNotifications.kt
@@ -65,15 +65,15 @@ object RemindersNotifications {
             if (AppPreferences.remindersAlarm(context)) {
 
                 // check tags
-                var noteTags = noteReminder.payload.tags.orEmpty().split(' ')
-                var alarmTags = AppPreferences.remindersAlarmTags(context).split(' ')
+                val noteTags = noteReminder.payload.tags.orEmpty().split(' ')
+                val alarmTags = AppPreferences.remindersAlarmTags(context).split(' ')
                 if (alarmTags.isEmpty() || noteTags.any { tag -> alarmTags.contains(tag) }) {
 
                     // ignore daily reminder time
                     // TODO this results in the notification not playing an alarm when the user
                     // schedules it on the exact time as the daily reminder. to still play the alarm in this case,
                     // we can check if the date of the note matches the daily reminder time
-                    var dailyTime = AppPreferences.reminderDailyTimeAsDateTime(context)
+                    val dailyTime = AppPreferences.reminderDailyTimeAsDateTime(context)
                     if (!noteReminder.runTime.equals(dailyTime)) {
 
                         // start alarm sound

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -32,6 +32,7 @@ import com.orgzly.android.db.entity.Book;
 import com.orgzly.android.db.entity.Note;
 import com.orgzly.android.db.entity.SavedSearch;
 import com.orgzly.android.prefs.AppPreferences;
+import com.orgzly.android.reminders.AlarmSoundService;
 import com.orgzly.android.sync.AutoSync;
 import com.orgzly.android.ui.AppSnackbarUtils;
 import com.orgzly.android.ui.CommonActivity;
@@ -461,6 +462,8 @@ public class MainActivity extends CommonActivity
         viewModel.refresh(AppPreferences.notebooksSortOrder(this));
 
         autoSync.trigger(AutoSync.Type.APP_RESUMED);
+
+        stopService(new Intent(this, AlarmSoundService.class));
     }
 
     private void performIntros() {

--- a/app/src/main/java/com/orgzly/android/ui/util/SystemServices.kt
+++ b/app/src/main/java/com/orgzly/android/ui/util/SystemServices.kt
@@ -10,6 +10,7 @@ import android.net.ConnectivityManager
 import android.os.storage.StorageManager
 import android.view.LayoutInflater
 import android.view.inputmethod.InputMethodManager
+import android.media.AudioManager
 
 fun Context.getNotificationManager(): NotificationManager {
     return getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -21,6 +22,10 @@ fun Context.getClipboardManager(): ClipboardManager {
 
 fun Context.getAlarmManager(): AlarmManager {
     return getSystemService(Context.ALARM_SERVICE) as AlarmManager
+}
+
+fun Context.getAudioManager(): AudioManager {
+    return getSystemService(Context.AUDIO_SERVICE) as AudioManager
 }
 
 fun Context.getConnectivityManager(): ConnectivityManager {

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -254,6 +254,12 @@
     <string name="pref_key_reminders_sound" translatable="false">pref_key_reminders_sound</string>
     <bool name="pref_default_reminders_sound" translatable="false">true</bool>
 
+    <string name="pref_key_reminders_alarm" translatable="false">pref_key_reminders_alarm</string>
+    <bool name="pref_default_reminders_alarm" translatable="false">false</bool>
+
+    <string name="pref_key_reminders_alarm_tags" translatable="false">pref_key_reminders_alarm_tags</string>
+    <string name="pref_default_reminders_alarm_tags" translatable="false">alarm</string>
+
     <string name="pref_key_reminders_vibrate" translatable="false">pref_key_reminders_vibrate</string>
     <bool name="pref_default_reminders_vibrate" translatable="false">false</bool>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,6 +487,11 @@
     <string name="pref_title_reminders_for_event_times">Events</string>
     <string name="pref_title_summary_reminders_for_event_times">Display notification for notes with event time</string>
 
+    <string name="pref_title_reminders_alarm">Alarm</string>
+    <string name="pref_summary_reminders_alarm">Play the system default alarm sound</string>
+    <string name="pref_title_reminders_alarm_tags">Alarm tags</string>
+    <string name="pref_summary_reminders_alarm_tags">Space separated list of tags that should trigger the alarm sound. Empty to trigger alarm on every reminder.</string>
+
     <string name="pref_title_reminders_sound">Sound</string>
     <string name="pref_title_reminders_vibrate">Vibration</string>
     <string name="pref_title_reminders_led">Light</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,8 +487,8 @@
     <string name="pref_title_reminders_for_event_times">Events</string>
     <string name="pref_title_summary_reminders_for_event_times">Display notification for notes with event time</string>
 
-    <string name="pref_title_reminders_alarm">Alarm</string>
-    <string name="pref_summary_reminders_alarm">Play the system default alarm sound</string>
+    <string name="pref_title_reminders_alarm">Play alarm sound</string>
+    <string name="pref_summary_reminders_alarm">For notes which have an "alarm tag" (see below)</string>
     <string name="pref_title_reminders_alarm_tags">Alarm tags</string>
     <string name="pref_summary_reminders_alarm_tags">Space separated list of tags that should trigger the alarm sound. Empty to trigger alarm on every reminder.</string>
 

--- a/app/src/main/res/xml/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml/prefs_screen_reminders.xml
@@ -24,6 +24,22 @@
         android:defaultValue="@bool/pref_default_use_reminders_for_event_times" />
 
     <SwitchPreference
+        android:key="@string/pref_key_reminders_alarm"
+        android:title="@string/pref_title_reminders_alarm"
+        android:summary="@string/pref_summary_reminders_alarm"
+        android:defaultValue="@bool/pref_default_reminders_alarm" />
+
+    <EditTextPreference
+        android:key="@string/pref_key_reminders_alarm_tags"
+        android:title="@string/pref_title_reminders_alarm_tags"
+        android:selectAllOnFocus="true"
+        android:inputType="text"
+        android:singleLine="true"
+        android:dialogMessage="@string/pref_summary_reminders_alarm_tags"
+        android:defaultValue="@string/pref_default_reminders_alarm_tags"
+        app:useSimpleSummaryProvider="true"/>
+
+    <SwitchPreference
         android:key="@string/pref_key_reminders_use_alarm_clock_for_tod_reminders"
         android:title="@string/use_alarm_clock_for_tod_reminders"
         android:summary="@string/use_alarm_clock_for_tod_reminders_summary"


### PR DESCRIPTION
After missing an appointment, I have added the option to play the default system alarm sound using the current alarm volume of the device. It is turned off by default to not interfere with anything. You can configure your own custom tags to trigger the alarm sound, while the default is to ring if a note contains the "alarm" tag. Clearing the custom tags results in every note ringing the alarm.

To stop the alarm, you need to dismiss the notification by either touching the title to open the note, mark it as done, or pressing the snooze button. After a snooze is expired, the alarm will ring again as expected.

The daily note reminder will not ring the alarm, by muting the alarm of any reminders set to the same clock as the daily note reminder. A small adjustment could improve this edge case in the future.

I did not touch the "Use alarm clock" (#49) option, as it seems to be a separate thing. I have looked into some options related scheduling alarms using the system default clock app, but I suspect it is more intended for one-off alarms in contrast to what is possible with org.

Finally, this seems to implement orgzly/orgzly-android#654. This is my first pull request, so I hope I did everything correctly. Thanks for maintaining orgzly!

Happy new year!