### PR TITLE
Clean up handling of the "schedule exact alarms" permission

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/AgendaFragmentTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/AgendaFragmentTest.java
@@ -164,7 +164,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
 
     @Test
     public void testMoveTaskWithRepeaterToTomorrow() {
-        EspressoUtils.grantAlarmsAndRemindersPermission();
+        EspressoUtils.grantAlarmsAndRemindersSpecialPermission();
         DateTime tomorrow = DateTime.now().withTimeAtStartOfDay().plusDays(1);
         scenario = defaultSetUp();
         searchForTextCloseKeyboard(".it.done ad.7");

--- a/app/src/androidTest/java/com/orgzly/android/espresso/MiscTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/MiscTest.java
@@ -189,7 +189,7 @@ public class MiscTest extends OrgzlyTest {
                         "*** DONE Note #5.\n" +
                         "CLOSED: [2014-06-03 Tue 13:34]\n" +
                         "");
-        EspressoUtils.grantAlarmsAndRemindersPermission();
+        EspressoUtils.grantAlarmsAndRemindersSpecialPermission();
         try (ActivityScenario<MainActivity> ignored = ActivityScenario.launch(MainActivity.class)) {
             onView(allOf(withText("book-name"), isDisplayed())).perform(click());
 
@@ -272,7 +272,7 @@ public class MiscTest extends OrgzlyTest {
 
     @Test
     public void testTimestampDialogTimeButtonValueWhenToggling() {
-        EspressoUtils.grantAlarmsAndRemindersPermission();
+        EspressoUtils.grantAlarmsAndRemindersSpecialPermission();
         testUtils.setupBook("book-name", "Sample book used for tests\n" +
                 "* TODO Note #1.\n" +
                 "SCHEDULED: <2015-01-18 04:05 +6d>\n" +

--- a/app/src/androidTest/java/com/orgzly/android/espresso/QueryFragmentTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/QueryFragmentTest.java
@@ -16,7 +16,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static com.orgzly.android.espresso.util.EspressoUtils.contextualToolbarOverflowMenu;
-import static com.orgzly.android.espresso.util.EspressoUtils.grantAlarmsAndRemindersPermission;
+import static com.orgzly.android.espresso.util.EspressoUtils.grantAlarmsAndRemindersSpecialPermission;
 import static com.orgzly.android.espresso.util.EspressoUtils.onActionItemClick;
 import static com.orgzly.android.espresso.util.EspressoUtils.onBook;
 import static com.orgzly.android.espresso.util.EspressoUtils.onNoteInBook;
@@ -257,7 +257,7 @@ public class QueryFragmentTest extends OrgzlyTest {
     @Test
     public void testSchedulingNote() {
         defaultSetUp();
-        grantAlarmsAndRemindersPermission();
+        grantAlarmsAndRemindersSpecialPermission();
 
         onView(withId(R.id.drawer_layout)).perform(open());
         onView(withText("Scheduled")).perform(click());

--- a/app/src/androidTest/java/com/orgzly/android/espresso/util/EspressoUtils.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/util/EspressoUtils.java
@@ -518,6 +518,13 @@ public class EspressoUtils {
         }
     }
 
+    public static void denyAlarmsAndRemindersSpecialPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            String shellCmd = "appops set --uid com.orgzlyrevived SCHEDULE_EXACT_ALARM deny";
+            getInstrumentation().getUiAutomation().executeShellCommand(shellCmd);
+        }
+    }
+
     /**
      * Utility method for starting sync using drawer button.
      */

--- a/app/src/androidTest/java/com/orgzly/android/espresso/util/EspressoUtils.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/util/EspressoUtils.java
@@ -511,7 +511,7 @@ public class EspressoUtils {
         };
     }
 
-    public static void grantAlarmsAndRemindersPermission() {
+    public static void grantAlarmsAndRemindersSpecialPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             String shellCmd = "appops set --uid com.orgzlyrevived SCHEDULE_EXACT_ALARM allow";
             getInstrumentation().getUiAutomation().executeShellCommand(shellCmd);
@@ -529,7 +529,7 @@ public class EspressoUtils {
      * Utility method for starting sync using drawer button.
      */
     public static void sync() {
-        grantAlarmsAndRemindersPermission();
+        grantAlarmsAndRemindersSpecialPermission();
         onView(withId(R.id.drawer_layout)).perform(open());
         onView(withId(R.id.sync_button_container)).perform(click());
         onView(withId(R.id.drawer_layout)).perform(close());

--- a/app/src/main/java/com/orgzly/android/sync/SyncWorker.kt
+++ b/app/src/main/java/com/orgzly/android/sync/SyncWorker.kt
@@ -1,10 +1,6 @@
 package com.orgzly.android.sync
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.os.Build
-import android.provider.Settings
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
@@ -17,9 +13,12 @@ import com.orgzly.android.data.logs.AppLogsRepository
 import com.orgzly.android.db.entity.BookAction
 import com.orgzly.android.prefs.AppPreferences
 import com.orgzly.android.reminders.RemindersScheduler
-import com.orgzly.android.repos.*
+import com.orgzly.android.repos.DirectoryRepo
+import com.orgzly.android.repos.RepoType
+import com.orgzly.android.repos.RepoUtils
+import com.orgzly.android.repos.SyncRepo
+import com.orgzly.android.repos.TwoWaySyncRepo
 import com.orgzly.android.ui.notifications.SyncNotifications
-import com.orgzly.android.ui.util.getAlarmManager
 import com.orgzly.android.ui.util.haveNetworkConnection
 import com.orgzly.android.util.AppPermissions
 import com.orgzly.android.util.LogMajorEvents
@@ -168,31 +167,6 @@ class SyncWorker(val context: Context, val params: WorkerParameters) :
                 return SyncState.getInstance(SyncState.Type.FAILED_NO_STORAGE_PERMISSION)
             }
         }
-
-        /* Make sure we have permission to set alarms & reminders,
-         * since this typically happens when new books are parsed.
-         */
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            if (!context.getAlarmManager().canScheduleExactAlarms()) {
-                if (
-                    AppPreferences.remindersForDeadlineEnabled(context) ||
-                    AppPreferences.remindersForScheduledEnabled(context) ||
-                    AppPreferences.remindersForEventsEnabled(context)
-                ) {
-                    if (App.getCurrentActivity() != null) {
-                        val uri = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
-                        App.getCurrentActivity().startActivity(
-                            Intent(
-                                Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
-                                uri
-                            )
-                        )
-                    }
-                    return SyncState.getInstance((SyncState.Type.FAILED_NO_ALARMS_PERMISSION))
-                }
-            }
-        }
-
 
         return null
     }

--- a/app/src/main/java/com/orgzly/android/ui/util/ActivityUtils.kt
+++ b/app/src/main/java/com/orgzly/android/ui/util/ActivityUtils.kt
@@ -9,7 +9,12 @@ import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.util.DisplayMetrics
-import android.view.*
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.ActionMenuItemView
 import androidx.appcompat.widget.Toolbar
@@ -33,6 +38,13 @@ object ActivityUtils {
 
         intent.data = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
 
+        activity.startActivity(intent)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    fun openAppScheduleExactAlarmsPermissionSetting(activity: Activity) {
+        val intent = Intent(android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+        intent.data = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
         activity.startActivity(intent)
     }
 

--- a/app/src/main/java/com/orgzly/android/util/AppPermissions.kt
+++ b/app/src/main/java/com/orgzly/android/util/AppPermissions.kt
@@ -9,9 +9,11 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.orgzly.BuildConfig
 import com.orgzly.R
+import com.orgzly.android.App
 import com.orgzly.android.ui.CommonActivity
 import com.orgzly.android.ui.showSnackbar
 import com.orgzly.android.ui.util.ActivityUtils
+import com.orgzly.android.ui.util.getAlarmManager
 
 object AppPermissions {
     private val TAG = AppPermissions::class.java.name
@@ -75,6 +77,7 @@ object AppPermissions {
             else
                 Manifest.permission.READ_EXTERNAL_STORAGE
             Usage.POST_NOTIFICATIONS -> Manifest.permission.POST_NOTIFICATIONS
+            Usage.SCHEDULE_EXACT_ALARM -> Manifest.permission.SCHEDULE_EXACT_ALARM
         }
     }
 
@@ -87,7 +90,21 @@ object AppPermissions {
             Usage.SAVED_SEARCHES_EXPORT_IMPORT -> R.string.storage_permissions_missing
             Usage.EXTERNAL_FILES_ACCESS -> R.string.permissions_rationale_for_external_files_access
             Usage.POST_NOTIFICATIONS -> R.string.permissions_rationale_for_post_notifications
+            Usage.SCHEDULE_EXACT_ALARM -> R.string.permissions_rationale_for_schedule_exact_alarms
         }
+    }
+
+    @JvmStatic
+    fun canScheduleExactAlarms(context: Context): Boolean {
+        var isGranted = true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !context.getAlarmManager().canScheduleExactAlarms()) {
+            isGranted = false
+            val activity = App.getCurrentActivity()
+            activity?.showSnackbar(rationaleForRequest(Usage.SCHEDULE_EXACT_ALARM), R.string.settings) {
+                ActivityUtils.openAppScheduleExactAlarmsPermissionSetting(activity)
+            }
+        }
+        return isGranted
     }
 
     enum class Usage {
@@ -96,6 +113,7 @@ object AppPermissions {
         SYNC_START,
         SAVED_SEARCHES_EXPORT_IMPORT,
         EXTERNAL_FILES_ACCESS,
-        POST_NOTIFICATIONS
+        POST_NOTIFICATIONS,
+        SCHEDULE_EXACT_ALARM,
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -280,7 +280,8 @@
     <string name="permissions_rationale_for_book_export">Exporting notebook requires storage permission</string>
     <string name="permissions_rationale_for_sync_start">Syncing with local repositories requires storage permission</string>
     <string name="permissions_rationale_for_external_files_access">Accessing external files requires storage permission</string>
-    <string name="permissions_rationale_for_post_notifications">Permission is required to post notifications</string>
+    <string name="permissions_rationale_for_post_notifications">Permission needed to post notifications</string>
+    <string name="permissions_rationale_for_schedule_exact_alarms">Permission needed to schedule reminders at exact times</string>
 
     <string name="cycle_visibility">Fold/Unfold All</string>
     <string name="running_database_update">Upgrading database…</string>


### PR DESCRIPTION
Instead of trying to make the same check in several places (and fail at
it) we'll just show a snackbar whenever we fail to schedule reminders,
which the user can click to reach the relevant app settings screen.

Also, stop using AlarmManager.setExact() for daily reminders, as that
method requires the "schedule exact alarm" permission for no good
reason. Use AlarmManager.set() instead, which means that the
notification will be delivered "approximately" at the specified time.

I also have a couple of simple tests, but I'll have to add them later,
because I haven't gotten them to play well together with other tests
(conflicting "appops" permission changes).

This should resolve issue #473.