### PR TITLE
Flake improvements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ captures/
 # Keystore files
 *.jks
 
+# Generated Kotlin files
+.kotlin
+
 ### Android Patch ###
 gen-external-apklibs
 

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ flycheck_*.el
 
 ### Gradle ###
 .gradle
+.project
 build/
 
 # Ignore Gradle GUI config

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,9 @@ flycheck_*.el
 # projectiles files
 .projectile
 
+# direnv
+.direnv
+
 ### Gradle ###
 .gradle
 .project

--- a/flake.lock
+++ b/flake.lock
@@ -18,62 +18,13 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nixgl": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1713543440,
-        "narHash": "sha256-lnzZQYG0+EXl/6NkGpyIz+FEOc/DSEG57AP1VsdeNrM=",
-        "owner": "nix-community",
-        "repo": "nixGL",
-        "rev": "310f8e49a149e4c9ea52f1adf70cdc768ec53f8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixGL",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660551188,
-        "narHash": "sha256-a1LARMMYQ8DPx1BgoI/UN4bXe12hhZkCNqdxNi6uS0g=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "441dc5d512153039f19ef198e662e4f3dbb9fd65",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1733581040,
-        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {
@@ -86,8 +37,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixgl": "nixgl",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    nixgl.url = "github:nix-community/nixGL";
   };
   outputs = {
     nixpkgs,
     flake-utils,
-    nixgl,
     ...
   }:
   flake-utils.lib.eachDefaultSystem (system: let
@@ -16,8 +14,8 @@
       inherit system;
       config = {
         android_sdk.accept_license = true;
+        allowUnfree = true;
       };
-      overlays = [nixgl.overlay];
     };
     cmakeVersion = "3.22.1";
     buildToolsVersion = "34.0.0";
@@ -56,28 +54,21 @@
   in {
     devShells = with pkgs; {
       default = mkShell {
-        buildInputs =
-          sharedDeps
-          ++ [gradle_8 watchman]
-          ++ (
-            if system == "x86_64-linux"
-            then [pkgs.nixgl.auto.nixGLDefault pkgs.nixgl.nixGLIntel]
-            else []
-          );
-          LC_ALL = "en_US.UTF-8";
-          LANG = "en_US.UTF-8";
-          CMAKE_DIR = cmakeDir;
-          ANDROID_HOME = android-home;
-          ANDROID_NDK_ROOT = "${android-home}/ndk-bundle";
-          ANDROID_SDK_BIN = android-home;
-          GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${aapt2Binary}";
-          shellHook =
-            ''
-              export JAVA_HOME=${pkgs.jdk17.home};
-              source ${android-sdk.out}/nix-support/setup-hook
-              export ORG_GRADLE_PROJECT_ANDROID_HOME="$ANDROID_HOME"
-              export PATH=${additionalPath}:$PATH
-            '';
+        buildInputs = sharedDeps ++ [gradle_8 watchman];
+        LC_ALL = "en_US.UTF-8";
+        LANG = "en_US.UTF-8";
+        CMAKE_DIR = cmakeDir;
+        ANDROID_HOME = android-home;
+        ANDROID_NDK_ROOT = "${android-home}/ndk-bundle";
+        ANDROID_SDK_BIN = android-home;
+        GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${aapt2Binary}";
+        shellHook =
+          ''
+            export JAVA_HOME=${pkgs.jdk17.home};
+            source ${android-sdk.out}/nix-support/setup-hook
+            export ORG_GRADLE_PROJECT_ANDROID_HOME="$ANDROID_HOME"
+            export PATH=${additionalPath}:$PATH
+          '';
       };
     };
   });


### PR DESCRIPTION
These are several changes I had to do before being able to work on Orgzly, so hopefully this makes it easier for other contributors to start.

# flake.nix
Luckily a flake.nix was available, which turned out to be working for me with a few tweaks. The first issue is the manually imported nixpkgs which I was unable to turn off the unfree package error for (Android SDK), without modifying the file. This is because the neccessary environment variable for this can only be passed in impure nix mode. However unfree packages can be easily enabled with a single line addition.
Further on, the nixgl dependency seems to as well require an impure build, and I could not make it work on my system. I removed the nixgl dependency from the build because I am not sure why it is neccessary in the first place. Please tell me if this is an issue.
Additionally, I updated the flake dependencies to a recent version using "nix flake update".
This all combined now allows me to run "nix develop" to get into a shell that can successfully run "./gradlew assembleDebug" to build the APK without issues, which is very convenient.

# .envrc
This allows to automatically load the flake environment when you change into the project directory, additionally it has a nice integration with Emacs as well. When direnv is installed and activated in a shell, it will query for permission to load the environment. This can also be disabled. The only minor downside in this being included is if somebody else uses a custom .envrc for some reason and has to take care of not commiting changes, however this seems to be standard pratice. Let me know if this is a problem.

# .gitignore
These additions were neccessary to keep a clean working directory after running the Gradle build.

Tagging @colonelpanic8 as the original author of the flake build that was added recently. Let me know if there is an issue! Thank you for adding the flake, as building Orgzly was much easier with it than last time I tried :+1: 