### PR TITLE
chore: crowdin.yml use %locale% for Fastlane

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,4 +4,4 @@ files:
   - source: /app/src/main/res/raw/orgzly_getting_started.org
     translation: /app/src/main/res/raw-%android_code%/%original_file_name%
   - source: /metadata/en-US/*.txt
-    translation: /metadata/%two_letters_code%/%original_file_name%
+    translation: /metadata/%locale%/%original_file_name%


### PR DESCRIPTION
According to [Crowdin Configuration File](https://support.crowdin.com/developer/configuration-file/) the `%two_letters_code%` won't work with full locales like `pt-BR`.
The change should fix it. Once merged I'll translate the short_description.txt for the Brazilian locale to check how it will be created. 