### PR TITLE
Updating any percentage/fraction cookies in parent of TODO/DONE items

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/AllTestSuite.kt
+++ b/app/src/androidTest/java/com/orgzly/android/AllTestSuite.kt
@@ -74,6 +74,7 @@ import org.junit.runners.Suite
         OrgFormatterMiscTest::class,
         OrgFormatterSpeedTest::class,
         OrgFormatterStyleTextTest::class,
+        StateChangeParentTitleUpdaterTest::class,
         UriUtilsTest::class
 )
 class AllTestSuite

--- a/app/src/androidTest/java/com/orgzly/android/util/StateChangeParentTitleUpdaterTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/util/StateChangeParentTitleUpdaterTest.kt
@@ -1,0 +1,96 @@
+package com.orgzly.android.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StateChangeParentTitleUpdaterTest {
+    private val defaultTodoKeywords get() = listOf("TODO")
+    private val defaultDoneKeywords get() = listOf("DONE")
+
+    private fun getTarget(
+        todoKeywords: Collection<String> = defaultTodoKeywords,
+        doneKeywords: Collection<String> = defaultDoneKeywords
+    ): StateChangeParentTitleUpdater {
+        return StateChangeParentTitleUpdater(todoKeywords, doneKeywords)
+    }
+
+    @Test
+    fun testTitleIsNotChangedWhenCookiesAreNotPresent() {
+        val target = getTarget()
+        val title = "This title will not be changed"
+
+        val result = target.updateTitleForStates(
+            title = title,
+            childStates = defaultTodoKeywords + defaultDoneKeywords
+        )
+
+        assertEquals(title, result)
+    }
+
+    @Test
+    fun testTitleIsNotChangedWhenTotalsHaveNotChanged() {
+        val target = getTarget()
+        val title = "This title will not be changed [50%] [1/2]"
+
+        val result = target.updateTitleForStates(
+            title = title,
+            childStates = defaultTodoKeywords + defaultDoneKeywords
+        )
+
+        assertEquals(title, result)
+    }
+
+    @Test
+    fun testTitleWithNewPercentageCookieIsUpdated() {
+        val target = getTarget()
+
+        val result = target.updateTitleForStates(
+            title = "This title will be changed [%]",
+            childStates = defaultTodoKeywords + defaultDoneKeywords
+        )
+
+        assertEquals("This title will be changed [50%]", result)
+    }
+
+    @Test
+    fun testTitleWithNewFractionCookieIsUpdated() {
+        val target = getTarget()
+
+        val result = target.updateTitleForStates(
+            title = "This title will be changed [/]",
+            childStates = defaultTodoKeywords + defaultDoneKeywords
+        )
+
+        assertEquals("This title will be changed [1/2]", result)
+    }
+
+    @Test
+    fun testTitleWithIncorrectPercentageCookieIsUpdated() {
+        val target = getTarget()
+        val testValues = listOf("0%", "1%", "100%", "1000%")
+
+        for (value in testValues) {
+            val result = target.updateTitleForStates(
+                title = "This title will be changed [$value]",
+                childStates = defaultTodoKeywords + defaultDoneKeywords
+            )
+
+            assertEquals("This title will be changed [50%]", result)
+        }
+    }
+
+    @Test
+    fun testTitleWithIncorrectFractionCookieIsUpdated() {
+        val target = getTarget()
+        val testValues = listOf("0/2", "2/2", "2/1", "200/100", "2/", "/1")
+
+        for (value in testValues) {
+            val result = target.updateTitleForStates(
+                title = "This title will be changed [$value]",
+                childStates = defaultTodoKeywords + defaultDoneKeywords
+            )
+
+            assertEquals("This title will be changed [1/2]", result)
+        }
+    }
+}

--- a/app/src/main/java/com/orgzly/android/util/StateChangeParentTitleUpdater.kt
+++ b/app/src/main/java/com/orgzly/android/util/StateChangeParentTitleUpdater.kt
@@ -1,0 +1,25 @@
+package com.orgzly.android.util
+
+import kotlin.math.roundToInt
+
+class StateChangeParentTitleUpdater(
+    private val todoKeywords: Collection<String>,
+    private val doneKeywords: Collection<String>
+) {
+    fun updateTitleForStates(title: String, childStates: Collection<String?>): String {
+        val percentageRegex = Regex("\\[\\d*%]")
+        val fractionRegex = Regex("\\[\\d*/\\d*]")
+
+        if (!percentageRegex.containsMatchIn(title) && !fractionRegex.containsMatchIn(title)) {
+            return title
+        }
+
+        val doneCount = childStates.count { this.doneKeywords.contains(it) }
+        val totalCount = doneCount + childStates.count { todoKeywords.contains(it) }
+        val percentage = ((doneCount.toDouble() / totalCount) * 100).roundToInt()
+
+        return title
+            .replace(percentageRegex, "[$percentage%]")
+            .replace(fractionRegex, "[$doneCount/$totalCount]")
+    }
+}


### PR DESCRIPTION
This is intended to address issue #525; apologies for applying business logic in the repository layer but I couldn't find any other spots to pull this off which wouldn't have required a bunch of repetitive changes (such as across the UseCases).  I'm certainly open to suggestion on reworking if this is in violation of standards/practices.