### PR TITLE
Adding parent title update to setNotesState per PR feedback

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/misc/StateChangeParentTitleUpdateTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/misc/StateChangeParentTitleUpdateTest.kt
@@ -5,6 +5,7 @@ import com.orgzly.android.ui.NotePlace
 import com.orgzly.android.ui.Place
 import com.orgzly.android.ui.note.NotePayload
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class StateChangeParentTitleUpdateTest : OrgzlyTest() {
@@ -228,5 +229,67 @@ class StateChangeParentTitleUpdateTest : OrgzlyTest() {
 
             assertEquals(expectedBook, exportedBook.trim())
         }
+    }
+
+    @Test
+    fun testTitleOfParentIsUpdatedWhenUsingSetNotesState() {
+         val book = testUtils.setupBook(
+            "book-a",
+            "* Things to do [%] [/]\n" +
+            "*** DONE Add percentage and fraction cookie handling for titles\n" +
+            "*** TODO Write integration tests for same")
+
+        val firstNote = dataRepository
+            .getLastNote("Add percentage and fraction cookie handling for titles")!!
+        val secondNote = dataRepository.getLastNote("Write integration tests for same")!!
+
+        dataRepository.setNotesState(
+            setOf(firstNote.id, secondNote.id),
+            "DONE"
+        )
+
+        // can't use exportBook here because there are going to be CLOSED stamps involved, and we
+        // don't know what date/time they will have.  instead we'll just look it up by the adjusted
+        // title it should have now, and if it's not null then we know it worked.
+
+        val parentNote = dataRepository.getLastNote("Things to do [100%] [2/2]")
+
+        assertNotNull(parentNote)
+    }
+
+    @Test
+    fun testTitleOfParentIsUpdatedWhenUsingSetNotesStateToDone() {
+         val book = testUtils.setupBook(
+            "book-a",
+            "* Things to do [%] [/]\n" +
+            "*** DONE Add percentage and fraction cookie handling for titles\n" +
+            "*** TODO Write integration tests for same")
+
+        val secondNote = dataRepository.getLastNote("Write integration tests for same")!!
+
+        dataRepository.setNoteStateToDone(secondNote.id)
+
+        val parentNote = dataRepository.getLastNote("Things to do [100%] [2/2]")
+
+        assertNotNull(parentNote)
+    }
+
+    @Test
+    fun testTitleOfParentIsUpdatedWhenUsingToggleNoteState() {
+         val book = testUtils.setupBook(
+            "book-a",
+            "* Things to do [%] [/]\n" +
+            "*** DONE Add percentage and fraction cookie handling for titles\n" +
+            "*** TODO Write integration tests for same")
+
+        val firstNote = dataRepository
+            .getLastNote("Add percentage and fraction cookie handling for titles")!!
+        val secondNote = dataRepository.getLastNote("Write integration tests for same")!!
+
+        dataRepository.toggleNotesState(setOf(firstNote.id, secondNote.id))
+
+        val parentNote = dataRepository.getLastNote("Things to do [100%] [2/2]")
+
+        assertNotNull(parentNote)
     }
 }

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -1152,12 +1152,20 @@ class DataRepository @Inject constructor(
                     if (scl.isShifted) {
                         replaceNoteEvents(note.noteId, title, content, null)
                     }
+
+                    tryUpdateTitleCookiesOfParent(note.noteId, scl.state)
                 }
 
                 updated
 
             } else { // Set to non-done state
-                db.note().updateStateAndRemoveClosedTime(noteIds, state)
+                val ret = db.note().updateStateAndRemoveClosedTime(noteIds, state)
+
+                for (noteId in noteIds) {
+                    tryUpdateTitleCookiesOfParent(noteId, state)
+                }
+
+                ret
             }
         })
     }
@@ -1509,16 +1517,7 @@ class DataRepository @Inject constructor(
 
         db.noteAncestor().insertAncestorsForNote(noteId)
 
-        val doneKeywords = AppPreferences.doneKeywordsSet(context)
-        val todoKeywords = AppPreferences.todoKeywordsSet(context)
-
-        if (doneKeywords.contains(notePayload.state) || todoKeywords.contains(notePayload.state)) {
-            val ancestors = getNoteAncestors(noteId)
-
-            if (ancestors.isNotEmpty()) {
-                tryUpdateTitleCookies(ancestors.last())
-            }
-        }
+        tryUpdateTitleCookiesOfParent(noteId, notePayload.state)
 
         tryUpdateTitleCookies(noteEntity.copy(id = noteId))
 
@@ -1604,6 +1603,19 @@ class DataRepository @Inject constructor(
 
             newNote
         })
+    }
+
+    private fun tryUpdateTitleCookiesOfParent(childNoteId: Long, childNoteState: String?) {
+        val doneKeywords = AppPreferences.doneKeywordsSet(context)
+        val todoKeywords = AppPreferences.todoKeywordsSet(context)
+
+        if (doneKeywords.contains(childNoteState) || todoKeywords.contains(childNoteState)) {
+            val ancestors = getNoteAncestors(childNoteId)
+
+            if (ancestors.isNotEmpty()) {
+                tryUpdateTitleCookies(ancestors.last())
+            }
+        }
     }
 
     private fun tryUpdateTitleCookies(note: Note) {

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -1153,7 +1153,7 @@ class DataRepository @Inject constructor(
                         replaceNoteEvents(note.noteId, title, content, null)
                     }
 
-                    tryUpdateTitleCookiesOfParent(note.noteId, scl.state)
+                    tryUpdateTitleCookiesOfParent(note.noteId)
                 }
 
                 updated
@@ -1162,7 +1162,7 @@ class DataRepository @Inject constructor(
                 val ret = db.note().updateStateAndRemoveClosedTime(noteIds, state)
 
                 for (noteId in noteIds) {
-                    tryUpdateTitleCookiesOfParent(noteId, state)
+                    tryUpdateTitleCookiesOfParent(noteId)
                 }
 
                 ret
@@ -1517,7 +1517,7 @@ class DataRepository @Inject constructor(
 
         db.noteAncestor().insertAncestorsForNote(noteId)
 
-        tryUpdateTitleCookiesOfParent(noteId, notePayload.state)
+        tryUpdateTitleCookiesOfParent(noteId)
 
         tryUpdateTitleCookies(noteEntity.copy(id = noteId))
 
@@ -1605,16 +1605,11 @@ class DataRepository @Inject constructor(
         })
     }
 
-    private fun tryUpdateTitleCookiesOfParent(childNoteId: Long, childNoteState: String?) {
-        val doneKeywords = AppPreferences.doneKeywordsSet(context)
-        val todoKeywords = AppPreferences.todoKeywordsSet(context)
+    private fun tryUpdateTitleCookiesOfParent(childNoteId: Long) {
+        val ancestors = getNoteAncestors(childNoteId)
 
-        if (doneKeywords.contains(childNoteState) || todoKeywords.contains(childNoteState)) {
-            val ancestors = getNoteAncestors(childNoteId)
-
-            if (ancestors.isNotEmpty()) {
-                tryUpdateTitleCookies(ancestors.last())
-            }
+        if (ancestors.isNotEmpty()) {
+            tryUpdateTitleCookies(ancestors.last())
         }
     }
 


### PR DESCRIPTION
Sorry this took me a bit, I had to deal with some "I also do this in real life for money" stuff this week.

There should be single choke points for creating/updating a note that all note creates/updates have to pass through, and that would be the ideal spot to maintain/enforce business logic like this.  I would make that a prime consideration for any refactor of the DataRepository class personally.