### PR TITLE
Adding parent title update to setNotesState per PR feedback

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/misc/StateChangeParentTitleUpdateTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/misc/StateChangeParentTitleUpdateTest.kt
@@ -5,6 +5,7 @@ import com.orgzly.android.ui.NotePlace
 import com.orgzly.android.ui.Place
 import com.orgzly.android.ui.note.NotePayload
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class StateChangeParentTitleUpdateTest : OrgzlyTest() {
@@ -228,5 +229,67 @@ class StateChangeParentTitleUpdateTest : OrgzlyTest() {
 
             assertEquals(expectedBook, exportedBook.trim())
         }
+    }
+
+    @Test
+    fun testTitleOfParentIsUpdatedWhenUsingSetNotesState() {
+         val book = testUtils.setupBook(
+            "book-a",
+            "* Things to do [%] [/]\n" +
+            "*** DONE Add percentage and fraction cookie handling for titles\n" +
+            "*** TODO Write integration tests for same")
+
+        val firstNote = dataRepository
+            .getLastNote("Add percentage and fraction cookie handling for titles")!!
+        val secondNote = dataRepository.getLastNote("Write integration tests for same")!!
+
+        dataRepository.setNotesState(
+            setOf(firstNote.id, secondNote.id),
+            "DONE"
+        )
+
+        // can't use exportBook here because there are going to be CLOSED stamps involved, and we
+        // don't know what date/time they will have.  instead we'll just look it up by the adjusted
+        // title it should have now, and if it's not null then we know it worked.
+
+        val parentNote = dataRepository.getLastNote("Things to do [100%] [2/2]")
+
+        assertNotNull(parentNote)
+    }
+
+    @Test
+    fun testTitleOfParentIsUpdatedWhenUsingSetNotesStateToDone() {
+         val book = testUtils.setupBook(
+            "book-a",
+            "* Things to do [%] [/]\n" +
+            "*** DONE Add percentage and fraction cookie handling for titles\n" +
+            "*** TODO Write integration tests for same")
+
+        val secondNote = dataRepository.getLastNote("Write integration tests for same")!!
+
+        dataRepository.setNoteStateToDone(secondNote.id)
+
+        val parentNote = dataRepository.getLastNote("Things to do [100%] [2/2]")
+
+        assertNotNull(parentNote)
+    }
+
+    @Test
+    fun testTitleOfParentIsUpdatedWhenUsingToggleNoteState() {
+         val book = testUtils.setupBook(
+            "book-a",
+            "* Things to do [%] [/]\n" +
+            "*** DONE Add percentage and fraction cookie handling for titles\n" +
+            "*** TODO Write integration tests for same")
+
+        val firstNote = dataRepository
+            .getLastNote("Add percentage and fraction cookie handling for titles")!!
+        val secondNote = dataRepository.getLastNote("Write integration tests for same")!!
+
+        dataRepository.toggleNotesState(setOf(firstNote.id, secondNote.id))
+
+        val parentNote = dataRepository.getLastNote("Things to do [100%] [2/2]")
+
+        assertNotNull(parentNote)
     }
 }


### PR DESCRIPTION
This addresses a comment from @amberin on the already merged pull/546: https://github.com/orgzly-revived/orgzly-android-revived/pull/546#issuecomment-2733055158:

> @functionreturnfunction Trying this out, I noticed that setNotesState ([master/app/src/main/java/com/orgzly/android/data/DataRepository.kt#L1093](https://github.com/orgzly-revived/orgzly-android-revived/blob/master/app/src/main/java/com/orgzly/android/data/DataRepository.kt?rgh-link-date=2025-03-18T12%3A31%3A53Z#L1093)) doesn't call tryUpdateTitleCookies. I kind of feel it would make sense for that method to call updateNote, but apparently it doesn't. Maybe you're aware of this already?

I had, in fact, missed that spot.

Also my prior PR for this change ([pull/551](https://github.com/orgzly-revived/orgzly-android-revived/pull/551)) had the commits doubled for some reason, so I closed that PR and redid my branch with a squash of those 3 commits to remove the oddities from the commit chain.