### PR TITLE
Directory repository: Avoid guessing file names from content:// URLs

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/repos/LocalDbRepoTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/repos/LocalDbRepoTest.java
@@ -82,7 +82,7 @@ public class LocalDbRepoTest extends OrgzlyTest {
 
         File tmpFile = dataRepository.getTempBookFile();
         try {
-            syncRepo.retrieveBook("mock-book.org", tmpFile);
+            syncRepo.retrieveBook(vrook.uri, tmpFile);
             String content = MiscUtils.readStringFromFile(tmpFile);
             assertEquals("book content\n" + "\n" + "* First note\n" + "** Second note", content);
         } finally {

--- a/app/src/androidTest/java/com/orgzly/android/repos/SyncTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/repos/SyncTest.java
@@ -1,16 +1,10 @@
 package com.orgzly.android.repos;
 
-import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static com.orgzly.android.espresso.util.EspressoUtils.onBook;
-import static org.hamcrest.Matchers.allOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -600,7 +594,7 @@ public class SyncTest extends OrgzlyTest {
      * force-loading.
      */
     @Test
-    public void testForceLoadBookInSubfolder() {
+    public void testForceLoadBookInSubfolder() throws IOException {
         Repo repo = testUtils.setupRepo(RepoType.MOCK, "mock://repo-a");
         BookView bookView = testUtils.setupBook("a folder/a book", "content");
         testUtils.sync();
@@ -673,24 +667,25 @@ public class SyncTest extends OrgzlyTest {
                 bookView.getBook().getLastAction().getMessage());
     }
 
-    @Test
-    public void testForceLoadingBookWithLink() throws IOException {
+    @Test(expected = IOException.class)
+    public void testForceLoadingBookWithLinkButNeverSynced() throws IOException {
         Repo repo = testUtils.setupRepo(RepoType.MOCK, "mock://repo-a");
         testUtils.setupRook(repo, "mock://repo-a/booky.org", "New content", "abc", 1234567890000L);
         Book book = testUtils.setupBook("booky", "First book used for testing\n* Note A").getBook();
         dataRepository.setLink(book.getId(), repo);
-        dataRepository.forceLoadBook(book.getId());
-
-        assertEquals(context.getString(R.string.force_loaded_from_uri, "mock://repo-a/booky.org")
-                , dataRepository.getBook(book.getName()).getLastAction().getMessage());
-        assertEquals("New content\n\n", dataRepository.getBookContent("booky", BookFormat.ORG));
+        try {
+            dataRepository.forceLoadBook(book.getId());
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("Notebook has never been synced before"));
+            throw new IOException(e);
+        }
     }
 
     /**
      * To ensure that book names are not parsed/constructed differently during force load
      */
     @Test
-    public void testForceLoadBookWithSpaceInName() {
+    public void testForceLoadBookWithSpaceInName() throws IOException {
         Repo repo = testUtils.setupRepo(RepoType.MOCK, "mock://repo-a");
         testUtils.setupRook(repo, "mock://repo-a/Book%20Name.org", "", "1abcdef", 1400067155);
 
@@ -704,7 +699,7 @@ public class SyncTest extends OrgzlyTest {
     }
 
     @Test
-    public void testForceLoadingBookWithNoLinkNoRepos() {
+    public void testForceLoadingBookWithNoLinkNoRepos() throws IOException {
         BookView book = testUtils.setupBook("booky", "First book used for testing\n* Note A");
 
         exceptionRule.expect(IOException.class);
@@ -713,34 +708,13 @@ public class SyncTest extends OrgzlyTest {
     }
 
     @Test
-    public void testForceLoadingBookWithNoLinkSingleRepo() {
+    public void testForceLoadingBookWithNoLinkSingleRepo() throws IOException {
         testUtils.setupRepo(RepoType.MOCK, "mock://repo-a");
         BookView book = testUtils.setupBook("booky", "First book used for testing\n* Note A");
 
         exceptionRule.expect(IOException.class);
         exceptionRule.expectMessage(context.getString(R.string.message_book_has_no_link));
         dataRepository.forceLoadBook(book.getBook().getId());
-    }
-
-    /* Books view was returning multiple entries for the same book, due to duplicates in encodings
-     * table. The last statement in this method will fail if there are multiple books matching.
-     */
-    @Test
-    public void testForceLoadingMultipleTimes() {
-        Repo repo = testUtils.setupRepo(RepoType.MOCK, "mock://repo-a");
-        testUtils.setupRook(repo, "mock://repo-a/book-one.org", "New content", "abc", 1234567890000L);
-        Book book = testUtils.setupBook("book-one", "First book used for testing\n* Note A").getBook();
-        dataRepository.setLink(book.getId(), repo);
-        dataRepository.forceLoadBook(book.getId());
-        assertEquals(
-            context.getString(R.string.force_loaded_from_uri, "mock://repo-a/book-one.org"),
-            dataRepository.getBook(book.getId()).getLastAction().getMessage()
-        );
-        dataRepository.forceLoadBook(book.getId());
-        assertEquals(
-                context.getString(R.string.force_loaded_from_uri, "mock://repo-a/book-one.org"),
-                dataRepository.getBook(book.getId()).getLastAction().getMessage()
-        );
     }
 
     @Test

--- a/app/src/main/java/com/orgzly/android/BookName.java
+++ b/app/src/main/java/com/orgzly/android/BookName.java
@@ -156,7 +156,7 @@ public class BookName {
                 String name = m.group(1);
                 String extension = m.group(2);
 
-                if (extension.equals("org")) {
+                if (extension != null && extension.equals("org")) {
                     return new BookName(repoRelativePath, name, BookFormat.ORG);
                 }
             }

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -80,14 +80,15 @@ class DataRepository @Inject constructor(
             if (book.linkRepo == null) {
                 throw IOException(resources.getString(R.string.message_book_has_no_link))
             }
+            if (book.syncedTo == null) {
+                throw IOException(resources.getString(R.string.message_book_has_no_rook))
+            }
 
             setBookLastActionAndSyncStatus(bookId, BookAction.forNow(
                     BookAction.Type.PROGRESS,
                     resources.getString(R.string.force_loading_from_uri, book.linkRepo.url)))
 
-            val repoRelativePath = BookName.getRepoRelativePath(book)
-
-            val loadedBook = loadBookFromRepo(book.linkRepo.id, book.linkRepo.type, book.linkRepo.url, repoRelativePath)
+            val loadedBook = loadBookFromRepo(book.linkRepo.id, book.linkRepo.type, book.linkRepo.url, book.syncedTo.uri)
 
             setBookLastActionAndSyncStatus(loadedBook!!.book.id, BookAction.forNow(
                     BookAction.Type.INFO,
@@ -1717,13 +1718,11 @@ class DataRepository @Inject constructor(
 
     @Throws(IOException::class)
     fun loadBookFromRepo(rook: Rook): BookView? {
-        val repoRelativePath = BookName.getRepoRelativePath(rook.repoUri, rook.uri)
-
-        return loadBookFromRepo(rook.repoId, rook.repoType, rook.repoUri.toString(), repoRelativePath)
+        return loadBookFromRepo(rook.repoId, rook.repoType, rook.repoUri.toString(), rook.uri)
     }
 
     @Throws(IOException::class)
-    fun loadBookFromRepo(repoId: Long, repoType: RepoType, repoUrl: String, repoRelativePath: String): BookView? {
+    fun loadBookFromRepo(repoId: Long, repoType: RepoType, repoUrl: String, uri: Uri): BookView? {
         val book: BookView?
 
         val repo = getRepoInstance(repoId, repoType, repoUrl)
@@ -1731,9 +1730,9 @@ class DataRepository @Inject constructor(
         val tmpFile = getTempBookFile()
         try {
             /* Download from repo. */
-            val vrook = repo.retrieveBook(repoRelativePath, tmpFile)
+            val vrook = repo.retrieveBook(uri, tmpFile)
 
-            val bookName = BookName.fromRepoRelativePath(repoRelativePath)
+            val bookName = BookName.fromRook(vrook)
 
             /* Store from file to Shelf. */
             book = loadBookFromFile(bookName.name, bookName.format, tmpFile, vrook)

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -72,6 +72,7 @@ class DataRepository @Inject constructor(
         private val resources: Resources,
         private val localStorage: LocalStorage) {
 
+    @Throws(IOException::class)
     fun forceLoadBook(bookId: Long) {
         val book = getBookView(bookId)
                 ?: throw IOException(resources.getString(R.string.book_does_not_exist_anymore))

--- a/app/src/main/java/com/orgzly/android/repos/DatabaseRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DatabaseRepo.java
@@ -2,6 +2,8 @@ package com.orgzly.android.repos;
 
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+
 import com.orgzly.android.data.DbRepoBookRepository;
 import com.orgzly.android.util.MiscUtils;
 import com.orgzly.android.util.UriUtils;
@@ -82,6 +84,7 @@ public class DatabaseRepo implements SyncRepo {
         dbRepo.deleteBook(uri);
     }
 
+    @NonNull
     @Override
     public String toString() {
         return repoUri.toString();

--- a/app/src/main/java/com/orgzly/android/repos/DatabaseRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DatabaseRepo.java
@@ -48,8 +48,7 @@ public class DatabaseRepo implements SyncRepo {
     }
 
     @Override
-    public VersionedRook retrieveBook(String repoRelativePath, File file) {
-        Uri uri = repoUri.buildUpon().appendPath(repoRelativePath).build();
+    public VersionedRook retrieveBook(Uri uri, File file) {
         return dbRepo.retrieveBook(repoId, repoUri, uri, file);
     }
 

--- a/app/src/main/java/com/orgzly/android/repos/DirectoryRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DirectoryRepo.java
@@ -10,8 +10,6 @@ import com.orgzly.android.db.entity.Repo;
 import com.orgzly.android.util.MiscUtils;
 import com.orgzly.android.util.UriUtils;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -26,7 +24,7 @@ public class DirectoryRepo implements SyncRepo {
 
     public static final String SCHEME = "file";
 
-    private File mDirectory;
+    private final File mDirectory;
 
     private final long repoId;
     private final Uri repoUri;
@@ -124,9 +122,7 @@ public class DirectoryRepo implements SyncRepo {
     }
 
     @Override
-    public VersionedRook retrieveBook(String repoRelativePath, File destinationFile) throws IOException {
-        Uri uri = repoUri.buildUpon().appendPath(repoRelativePath).build();
-
+    public VersionedRook retrieveBook(Uri uri, File destinationFile) throws IOException {
         String path = uri.getPath();
 
         if (path == null) {
@@ -229,7 +225,6 @@ public class DirectoryRepo implements SyncRepo {
         return mDirectory;
     }
 
-    @NotNull
     @Override
     public String toString() {
         return repoUri.toString();

--- a/app/src/main/java/com/orgzly/android/repos/DirectoryRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DirectoryRepo.java
@@ -4,6 +4,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.orgzly.android.BookName;
 import com.orgzly.android.LocalStorage;
 import com.orgzly.android.db.entity.Repo;
@@ -225,6 +227,7 @@ public class DirectoryRepo implements SyncRepo {
         return mDirectory;
     }
 
+    @NonNull
     @Override
     public String toString() {
         return repoUri.toString();

--- a/app/src/main/java/com/orgzly/android/repos/DocumentRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DocumentRepo.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.provider.DocumentsContract;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.documentfile.provider.DocumentFile;
 
 import com.orgzly.BuildConfig;
@@ -161,6 +162,7 @@ public class DocumentRepo implements SyncRepo {
 
         /* "Download" the file. */
         try (InputStream is = context.getContentResolver().openInputStream(sourceFile.getUri())) {
+            assert is != null;
             MiscUtils.writeStreamToFile(is, destinationFile);
         }
 
@@ -222,7 +224,7 @@ public class DocumentRepo implements SyncRepo {
         DocumentFile currentDir = repoDocumentFile;
         while (levels.size() > 1) {
             String nextDirName = levels.remove(0);
-            DocumentFile nextDir = currentDir.findFile(nextDirName);
+            DocumentFile nextDir = Objects.requireNonNull(currentDir).findFile(nextDirName);
             if (nextDir == null) {
                 currentDir = currentDir.createDirectory(nextDirName);
             } else {
@@ -243,7 +245,7 @@ public class DocumentRepo implements SyncRepo {
      */
     @Override
     public VersionedRook renameBook(Uri oldFullUri, String newName) throws IOException {
-        DocumentFile oldDocFile = DocumentFile.fromSingleUri(context, oldFullUri);
+        DocumentFile oldDocFile = Objects.requireNonNull(DocumentFile.fromSingleUri(context, oldFullUri));
         long mtime = oldDocFile.lastModified();
         String rev = String.valueOf(mtime);
         String oldDocFileName = oldDocFile.getName();
@@ -255,7 +257,7 @@ public class DocumentRepo implements SyncRepo {
         );
         BookName oldBookName = BookName.fromRepoRelativePath(BookName.getRepoRelativePath(repoUri, oldFullUri));
         String newRelativePath = BookName.repoRelativePath(newName, oldBookName.getFormat());
-        String newDocFileName = Uri.parse(newRelativePath).getLastPathSegment();
+        String newDocFileName = Objects.requireNonNull(Uri.parse(newRelativePath).getLastPathSegment());
         DocumentFile newDir;
         Uri newUri = oldFullUri;
 
@@ -283,6 +285,7 @@ public class DocumentRepo implements SyncRepo {
                         oldDirUri,
                         newDir.getUri()
                 );
+                assert newUri != null;
             } else {
                 throw new IllegalArgumentException(
                         context.getString(R.string.moving_between_subdirectories_requires_api_24));
@@ -296,6 +299,7 @@ public class DocumentRepo implements SyncRepo {
                     newUri,
                     newDocFileName
             );
+            assert newUri != null;
         }
 
         return new VersionedRook(repoId, RepoType.DOCUMENT, repoUri, newUri, rev, mtime);
@@ -312,6 +316,7 @@ public class DocumentRepo implements SyncRepo {
         }
     }
 
+    @NonNull
     @Override
     public String toString() {
         return getUri().toString();

--- a/app/src/main/java/com/orgzly/android/repos/DropboxClient.java
+++ b/app/src/main/java/com/orgzly/android/repos/DropboxClient.java
@@ -228,10 +228,8 @@ public class DropboxClient {
     /**
      * Download file from Dropbox and store it to a local file.
      */
-    public VersionedRook download(Uri repoUri, String repoRelativePath, File localFile) throws IOException {
+    public VersionedRook download(Uri repoUri, Uri uri, File localFile) throws IOException {
         linkedOrThrow();
-
-        Uri uri = getFullUriFromRelativePath(repoUri, repoRelativePath);
 
         OutputStream out = new BufferedOutputStream(new FileOutputStream(localFile));
 

--- a/app/src/main/java/com/orgzly/android/repos/DropboxRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DropboxRepo.java
@@ -48,8 +48,8 @@ public class DropboxRepo implements SyncRepo {
     }
 
     @Override
-    public VersionedRook retrieveBook(String repoRelativePath, File file) throws IOException {
-        return client.download(repoUri, repoRelativePath, file);
+    public VersionedRook retrieveBook(Uri uri, File file) throws IOException {
+        return client.download(repoUri, uri, file);
     }
 
     @Override

--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -209,16 +209,14 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
     }
 
     @Override
-    public VersionedRook retrieveBook(String repoRelativePath, File destination) throws IOException {
-
-        Uri sourceUri = Uri.parse("/" + repoRelativePath);
+    public VersionedRook retrieveBook(Uri uri, File destination) throws IOException {
 
         // Ensure our repo copy is up-to-date. This is necessary when force-loading a book.
         synchronizer.mergeWithRemote();
 
-        synchronizer.retrieveLatestVersionOfFile(sourceUri.getPath(), destination);
+        synchronizer.retrieveLatestVersionOfFile(uri.getPath(), destination);
 
-        return currentVersionedRook(sourceUri);
+        return currentVersionedRook(uri);
     }
 
     @Override

--- a/app/src/main/java/com/orgzly/android/repos/MockRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/MockRepo.java
@@ -64,9 +64,9 @@ public class MockRepo implements SyncRepo {
     }
 
     @Override
-    public VersionedRook retrieveBook(String repoRelativePath, File file) throws IOException {
+    public VersionedRook retrieveBook(Uri uri, File file) throws IOException {
         SystemClock.sleep(SLEEP_FOR_RETRIEVE_BOOK);
-        return databaseRepo.retrieveBook(repoRelativePath, file);
+        return databaseRepo.retrieveBook(uri, file);
     }
 
     @Override

--- a/app/src/main/java/com/orgzly/android/repos/SyncRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/SyncRepo.java
@@ -31,7 +31,7 @@ public interface SyncRepo {
     /**
      * Download the latest available revision of the book and store its content to {@code File}.
      */
-    VersionedRook retrieveBook(String repoRelativePath, File destination) throws IOException;
+    VersionedRook retrieveBook(Uri uri, File destination) throws IOException;
 
     /**
      * Open a file in the repository for reading. Originally added for parsing the .orgzlyignore

--- a/app/src/main/java/com/orgzly/android/repos/SyncRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/SyncRepo.java
@@ -2,6 +2,8 @@ package com.orgzly.android.repos;
 
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,5 +64,6 @@ public interface SyncRepo {
 
     void delete(Uri uri) throws IOException;
 
+    @NonNull
     String toString();
 }

--- a/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
+++ b/app/src/main/java/com/orgzly/android/repos/WebdavRepo.kt
@@ -195,16 +195,14 @@ class WebdavRepo(
                 .toMutableList()
     }
 
-    override fun retrieveBook(repoRelativePath: String?, destination: File?): VersionedRook {
-        val fileUrl = Uri.withAppendedPath(uri, repoRelativePath).toUrl()
-
-        sardine.get(fileUrl).use { inputStream ->
+    override fun retrieveBook(uri: Uri, destination: File): VersionedRook {
+        sardine.get(uri.toUrl()).use { inputStream ->
             FileOutputStream(destination).use { outputStream ->
                 inputStream.copyTo(outputStream)
             }
         }
 
-        return sardine.list(fileUrl).first().toVersionedRook()
+        return sardine.list(uri.toUrl()).first().toVersionedRook()
     }
 
     override fun openRepoFileInputStream(repoRelativePath: String): InputStream {

--- a/app/src/main/java/com/orgzly/android/sync/BookNamesake.java
+++ b/app/src/main/java/com/orgzly/android/sync/BookNamesake.java
@@ -6,6 +6,7 @@ import com.orgzly.android.db.entity.BookView;
 import com.orgzly.android.db.entity.Repo;
 import com.orgzly.android.repos.VersionedRook;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +36,7 @@ public class BookNamesake {
     /**
      * Create links between each local book and each remote book with the same name.
      */
-    public static Map<String, BookNamesake> getAll(List<BookView> books, List<VersionedRook> versionedRooks) {
+    public static Map<String, BookNamesake> getAll(List<BookView> books, List<VersionedRook> versionedRooks) throws IOException {
         Map<String, BookNamesake> namesakes = new HashMap<>();
 
         /* Create links from all local books first. */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="ssh_keygen_preference_summary">Generate key pair for Git repo sync</string>
     <string name="ssh_show_public_key_preference_title">View generated SSH public key</string>
     <string name="message_book_has_no_link">Notebook has no repository link</string>
+    <string name="message_book_has_no_rook">Notebook has no known remote namesake</string>
     <string name="message_note_created">Note created</string>
     <string name="drawer_close">Close drawer</string>
     <string name="drawer_open">Open drawer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,7 +80,7 @@
     <string name="ssh_keygen_preference_summary">Generate key pair for Git repo sync</string>
     <string name="ssh_show_public_key_preference_title">View generated SSH public key</string>
     <string name="message_book_has_no_link">Notebook has no repository link</string>
-    <string name="message_book_has_no_rook">Notebook has no known remote namesake</string>
+    <string name="message_book_has_no_rook">Notebook has never been synced before</string>
     <string name="message_note_created">Note created</string>
     <string name="drawer_close">Close drawer</string>
     <string name="drawer_open">Open drawer</string>


### PR DESCRIPTION
Some DocumentFiles do not work at all with the guessing of file and directory names from content:// URLs, which I introduced in #312. (I knew it was sort of wrong, but it seemed to work...)

This solution should not be noticeably slower than the previous one. The only situation in which we need to walk the file tree from top to bottom in order get the full repo-relative path from a file URL, is when we are renaming files. And that is a very rare operation which doesn't need to be fast.

The biggest change here is in the signature of SyncRepo.retrieveBook, which now takes a URI, instead of a repo-relative path string. This required poking in quite a few different places, but the tests are paying off.

This closes issue #381.