### PR TITLE
Fix mtime not updating in directory repo

### DIFF
--- a/app/src/main/java/com/orgzly/android/repos/DocumentRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/DocumentRepo.java
@@ -190,8 +190,7 @@ public class DocumentRepo implements SyncRepo {
 
         DocumentFile existingFile = destinationDir.findFile(fileName);
         if (existingFile != null) {
-            // #536: Delete existing file to ensure fresh timestamp
-            existingFile.delete();
+            existingFile.delete();  // #536: Delete existing file to ensure fresh timestamp
         }
 
         DocumentFile destinationFile = destinationDir.createFile("text/*", fileName);
@@ -201,7 +200,9 @@ public class DocumentRepo implements SyncRepo {
             MiscUtils.writeFileToStream(file, out);
         }
 
-        long mtime = destinationFile.lastModified();
+        // We can't use destinationFile.lastModified() here, because some
+        // ContentProviders will not yet have set it.
+        long mtime = System.currentTimeMillis();
         String rev = String.valueOf(mtime);
 
         return new VersionedRook(repoId, RepoType.DOCUMENT, getUri(), destinationFile.getUri(), rev, mtime);


### PR DESCRIPTION
Before 43d88fd, files were always deleted and then re-created, before being written to. I removed this in https://github.com/orgzly-revived/orgzly-android-revived/commit/43d88fdb750e14eabe86bd821713aa21f9bc2f4b because it seemed pointless. But after reading up on modification time issues with SAF (see e.g. https://stackoverflow.com/a/30637159), I suspect that the deletion may have been added to ensure that the file's mtime is updated. So let's put
it back.

This should hopefully resolve both #536 and #218.

The second commit reverts another change in the same commit. We go back to storing mtime/revision as a time stamp set by Orgzly, rather than asking the file system for a timestamp. It turns out that SAF will not always be able to provide a time stamp so shortly after file creation.