### PR TITLE
Ignore hidden files in git repos

### DIFF
--- a/app/src/main/java/com/orgzly/android/repos/GitRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/GitRepo.java
@@ -267,7 +267,10 @@ public class GitRepo implements SyncRepo, TwoWaySyncRepo {
             public boolean include(TreeWalk walker) {
                 final FileMode mode = walk.getFileMode();
                 final boolean isDirectory = mode == FileMode.TREE;
+                final String name = walk.getNameString();
                 final String repoRelativePath = walk.getPathString();
+                if (name.startsWith("."))
+                    return false;
                 if (ignores.isIgnored(repoRelativePath, isDirectory) == IgnoreNode.MatchResult.IGNORED)
                     return false;
                 if (isDirectory)


### PR DESCRIPTION
Implements #607 

Issues:
- at least merged with https://github.com/amberin/orgzly-android-revived/tree/git-sync-push-first-master-updates-250406 maybe also on master non-org files make orgzly trip. With this fix, it still trips over hidden non-org files, so there  is some other channel communicating file existance.
  