### PR TITLE
[small] feature: Implement saved search query to display the search name in title, instead of the default "Agenda" or "Search".

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/TestUtils.java
+++ b/app/src/androidTest/java/com/orgzly/android/TestUtils.java
@@ -189,4 +189,13 @@ public class TestUtils {
         mockSerializedDbxCredential.put("app_key", BuildConfig.DROPBOX_APP_KEY);
         AppPreferences.dropboxSerializedCredential(App.getAppContext(), mockSerializedDbxCredential.toString());
     }
+
+    /**
+     * Creates a saved search with the given name and query.
+     * @param name Name of the saved search
+     * @param query Search query
+     */
+    public void createSavedSearch(String name, String query) {
+        dataRepository.createSavedSearch(new com.orgzly.android.db.entity.SavedSearch(0, name, query, 0));
+    }
 }

--- a/app/src/androidTest/java/com/orgzly/android/espresso/QueryFragmentTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/QueryFragmentTest.java
@@ -5,6 +5,7 @@ import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.contrib.DrawerActions.open;
 import static androidx.test.espresso.contrib.PickerActions.setDate;
 import static androidx.test.espresso.contrib.PickerActions.setTime;
@@ -41,6 +42,7 @@ import android.widget.DatePicker;
 import android.widget.TextView;
 import android.widget.TimePicker;
 import android.os.SystemClock;
+import android.widget.Toolbar;
 
 import androidx.test.core.app.ActivityScenario;
 
@@ -49,6 +51,8 @@ import com.orgzly.android.OrgzlyTest;
 import com.orgzly.android.prefs.AppPreferences;
 import com.orgzly.android.ui.main.MainActivity;
 import com.orgzly.org.datetime.OrgDateTime;
+import com.orgzly.android.ui.notes.query.agenda.AgendaFragment;
+import com.orgzly.android.ui.notes.query.search.SearchFragment;
 
 import org.junit.After;
 import org.junit.Ignore;
@@ -860,5 +864,62 @@ public class QueryFragmentTest extends OrgzlyTest {
         scenario = ActivityScenario.launch(MainActivity.class);
         searchForTextCloseKeyboard("s.no");
         onNotesInSearch().check(matches(recyclerViewItemCount(1)));
+    }
+
+    @Test
+    public void testSavedSearchAgendaFragmentDisplaysCorrectTitle() {
+        defaultSetUp();
+
+        // Create a saved search with Agenda View
+        testUtils.createSavedSearch("My Agenda", ".it.done ad.7");
+        scenario = ActivityScenario.launch(MainActivity.class);
+
+        // Open drawer
+        onView(withId(R.id.drawer_layout)).perform(open());
+
+        // Click on the saved search
+        onView(withText("My Agenda")).perform(click());
+
+        // Verify AgendaFragment is displayed
+        onView(withId(R.id.fragment_query_agenda_recycler_view)).check(matches(isDisplayed()));
+
+        // Verify SearchFragment is NOT displayed
+        onView(withId(R.id.fragment_query_search_recycler_view)).check(doesNotExist());
+
+        // Verify the title in the toolbar
+        onView(allOf(
+            instanceOf(TextView.class),
+            withParent(withId(R.id.top_toolbar)),
+            withText("My Agenda")
+        )).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void testSavedSearchSearchFragmentDisplaysCorrectTitle() {
+        defaultSetUp();
+
+        // Create a saved search
+        testUtils.createSavedSearch("My Search", "i.todo");
+        scenario = ActivityScenario.launch(MainActivity.class);
+
+        // Open drawer
+        onView(withId(R.id.drawer_layout)).perform(open());
+
+        // Click on the saved search
+        onView(withText("My Search")).perform(click());
+
+        SystemClock.sleep(200);
+
+        // Verify SearchFragment is displayed
+        onView(withId(R.id.fragment_query_search_recycler_view)).check(matches(isDisplayed()));
+
+        // Verify AgendaFragment is NOT displayed
+        onView(withId(R.id.fragment_query_agenda_recycler_view)).check(doesNotExist());
+
+        onView(allOf(
+                instanceOf(TextView.class),
+                withParent(withId(R.id.top_toolbar)),
+                withText("My Search")
+        )).check(matches(isDisplayed()));
     }
 }

--- a/app/src/main/java/com/orgzly/android/AppIntent.java
+++ b/app/src/main/java/com/orgzly/android/AppIntent.java
@@ -48,6 +48,7 @@ public class AppIntent {
     public static final String EXTRA_NOTE_ID = "com.orgzly.intent.extra.NOTE_ID";
     public static final String EXTRA_NOTE_CONTENT = "com.orgzly.intent.extra.NOTE_CONTENT";
     public static final String EXTRA_QUERY_STRING = "com.orgzly.intent.extra.QUERY_STRING";
+    public static final String EXTRA_SEARCH_NAME = "com.orgzly.intent.extra.SEARCH_NAME";
     public static final String EXTRA_PROPERTY_NAME  = "com.orgzly.intent.extra.PROPERTY_NAME";
     public static final String EXTRA_PROPERTY_VALUE  = "com.orgzly.intent.extra.PROPERTY_VALUE";
     public static final String EXTRA_PATH  = "com.orgzly.intent.extra.PATH";

--- a/app/src/main/java/com/orgzly/android/ui/DisplayManager.java
+++ b/app/src/main/java/com/orgzly/android/ui/DisplayManager.java
@@ -174,6 +174,10 @@ public class DisplayManager {
     }
 
     public static void displayQuery(FragmentManager fragmentManager, @NonNull String queryString) {
+        displayQuery(fragmentManager, queryString, null);
+    }
+
+    public static void displayQuery(FragmentManager fragmentManager, @NonNull String queryString, @Nullable String searchName) {
         // If the same query is already displayed, don't do anything.
         String displayedQuery = getDisplayedQuery(fragmentManager);
         if (displayedQuery != null && displayedQuery.equals(queryString)) {
@@ -189,11 +193,11 @@ public class DisplayManager {
 
         // Display agenda or query fragment
         if (query.getOptions().getAgendaDays() > 0) {
-            fragment = AgendaFragment.getInstance(queryString);
+            fragment = AgendaFragment.getInstance(queryString, searchName);
             tag = AgendaFragment.FRAGMENT_TAG;
 
         } else {
-            fragment = SearchFragment.getInstance(queryString);
+            fragment = SearchFragment.getInstance(queryString, searchName);
             tag = SearchFragment.FRAGMENT_TAG;
         }
 

--- a/app/src/main/java/com/orgzly/android/ui/drawer/DrawerNavigationView.kt
+++ b/app/src/main/java/com/orgzly/android/ui/drawer/DrawerNavigationView.kt
@@ -88,6 +88,7 @@ internal class DrawerNavigationView(
         savedSearches.forEach { savedSearch ->
             val intent = Intent(AppIntent.ACTION_OPEN_QUERY)
             intent.putExtra(AppIntent.EXTRA_QUERY_STRING, savedSearch.query)
+            intent.putExtra(AppIntent.EXTRA_SEARCH_NAME, savedSearch.name)
 
             val id = generateRandomUniqueId()
             val item = menu.add(R.id.drawer_group, id, 1, savedSearch.name)

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -203,7 +203,7 @@ public class MainActivity extends CommonActivity
                     DisplayManager.displayExistingNote(getSupportFragmentManager(), bookId, noteId);
                 }
             } else if (queryString != null) {
-                DisplayManager.displayQuery(getSupportFragmentManager(), queryString);
+                DisplayManager.displayQuery(getSupportFragmentManager(), queryString, null);
 
             } else {
                 handleOrgProtocolIntent(getIntent());
@@ -317,8 +317,8 @@ public class MainActivity extends CommonActivity
             }
         });
 
-        sharedMainActivityViewModel.getOpenDrawerRequest().observeSingle(this, open -> {
-            if (open) {
+        sharedMainActivityViewModel.getOpenDrawerRequest().observeSingle(this, value -> {
+            if (value != null && value) {
                 mDrawerLayout.openDrawer(GravityCompat.START);
             } else {
                 mDrawerLayout.closeDrawer(GravityCompat.START);
@@ -373,7 +373,8 @@ public class MainActivity extends CommonActivity
 
                 DisplayManager.displayQuery(
                         getSupportFragmentManager(),
-                        thisAction.getQuery());
+                        thisAction.getQuery(),
+                        null);
             }
         });
 
@@ -906,12 +907,6 @@ public class MainActivity extends CommonActivity
         LocalBroadcastManager.getInstance(App.getAppContext()).sendBroadcast(intent);
     }
 
-    public static void openQuery(String query) {
-        Intent intent = new Intent(AppIntent.ACTION_OPEN_QUERY);
-        intent.putExtra(AppIntent.EXTRA_QUERY_STRING, query);
-        LocalBroadcastManager.getInstance(App.getAppContext()).sendBroadcast(intent);
-    }
-
     @Override
     public void onClockIn(@NonNull Set<Long> noteIds) {
         viewModel.clockingUpdateRequest(noteIds, 0);
@@ -953,7 +948,8 @@ public class MainActivity extends CommonActivity
 
                 case AppIntent.ACTION_OPEN_QUERY: {
                     String query = intent.getStringExtra(AppIntent.EXTRA_QUERY_STRING);
-                    DisplayManager.displayQuery(getSupportFragmentManager(), query);
+                    String searchName = intent.getStringExtra(AppIntent.EXTRA_SEARCH_NAME);
+                    DisplayManager.displayQuery(getSupportFragmentManager(), query, searchName);
                     break;
                 }
 

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
@@ -4,16 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import android.view.MotionEvent
-import android.view.View
-import android.widget.PopupWindow
 import androidx.lifecycle.ViewModelProvider
 import com.orgzly.R
 import com.orgzly.android.sync.SyncRunner
 import com.orgzly.android.ui.dialogs.TimestampDialogFragment
 import com.orgzly.android.ui.drawer.DrawerItem
 import com.orgzly.android.ui.main.SharedMainActivityViewModel
-import com.orgzly.android.ui.notes.NotePopup
 import com.orgzly.android.ui.notes.NotesFragment
 import com.orgzly.android.ui.settings.SettingsActivity
 
@@ -28,12 +24,14 @@ abstract class QueryFragment :
     /** Currently active query.  */
     var currentQuery: String? = null
 
+    /** Currently active query name. */
+    var currentQueryName: String? = null
+
     protected var listener: Listener? = null
 
     protected lateinit var sharedMainActivityViewModel: SharedMainActivityViewModel
 
     protected lateinit var viewModel: QueryViewModel
-
 
     override fun getCurrentListener(): Listener? {
         return listener
@@ -49,6 +47,7 @@ abstract class QueryFragment :
         listener = activity as Listener
 
         currentQuery = requireArguments().getString(ARG_QUERY)
+        currentQueryName = requireArguments().getString(ARG_QUERY_NAME)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -120,6 +119,7 @@ abstract class QueryFragment :
         private val TAG = QueryFragment::class.java.name
 
         const val ARG_QUERY = "query"
+        const val ARG_QUERY_NAME = "query_name"
 
         fun getDrawerItemId(query: String?): String {
             return "$TAG $query"

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
@@ -153,7 +153,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
                 binding.topToolbar.menu.findItem(R.id.search_view)?.expandActionView()
             }
 
-            title = getString(R.string.agenda)
+            title = currentQueryName ?: getString(R.string.agenda)
             subtitle = currentQuery
         }
     }
@@ -315,14 +315,20 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
         @JvmField
         val FRAGMENT_TAG: String = AgendaFragment::class.java.name
 
+        @JvmStatic
+        fun getInstance(query: String): AgendaFragment {
+            return getInstance(query, null)
+        }
 
         @JvmStatic
-        fun getInstance(query: String): QueryFragment {
+        fun getInstance(query: String, queryName: String? = null): AgendaFragment {
             val fragment = AgendaFragment()
 
             val args = Bundle()
             args.putString(ARG_QUERY, query)
-
+            if (queryName != null) {
+                args.putString(ARG_QUERY_NAME, queryName)
+            }
             fragment.arguments = args
 
             return fragment

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/search/SearchFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/search/SearchFragment.kt
@@ -151,7 +151,7 @@ class SearchFragment : QueryFragment(), OnViewHolderClickListener<NoteView> {
                 binding.topToolbar.menu.findItem(R.id.search_view)?.expandActionView()
             }
 
-            title = getString(R.string.search)
+            title = currentQueryName ?: getString(R.string.search)
             subtitle = currentQuery
         }
     }
@@ -302,12 +302,19 @@ class SearchFragment : QueryFragment(), OnViewHolderClickListener<NoteView> {
         val FRAGMENT_TAG: String = SearchFragment::class.java.name
 
         @JvmStatic
-        fun getInstance(query: String): QueryFragment {
+        fun getInstance(query: String): SearchFragment {
+            return getInstance(query, null)
+        }
+
+        @JvmStatic
+        fun getInstance(query: String, queryName: String? = null): SearchFragment {
             val fragment = SearchFragment()
 
             val args = Bundle()
             args.putString(ARG_QUERY, query)
-
+            if (queryName != null) {
+                args.putString(ARG_QUERY_NAME, queryName)
+            }
             fragment.arguments = args
 
             return fragment


### PR DESCRIPTION
The saved searches are displaying "Agenda" or "Search" in the title today, which is a bit uninformative.  When I have custom queries, it's a bit difficult to know what the query is about. Changing them to match the search query name.