### PR TITLE
Feature: display last sync status on a NoteFragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,6 +116,12 @@ android {
         checkDependencies true
         disable 'MissingTranslation', 'MissingQuantity', 'ImpliedQuantity', 'InvalidPackage'
     }
+
+    sourceSets {
+        androidTest {
+            assets.srcDirs += files("$projectDir/schemas")
+        }
+    }
 }
 
 dependencies {
@@ -160,6 +166,7 @@ dependencies {
     testImplementation "io.github.atetzner:webdav-embedded-server:$versions.webdav_embedded_server"
 
     // Android instrumented tests
+    androidTestImplementation "androidx.room:room-testing:$versions.android_room"
     androidTestImplementation(project(":shared-test"))
     androidTestImplementation "androidx.test.espresso:espresso-core:$versions.android_test_espresso"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$versions.android_test_espresso"

--- a/app/schemas/com.orgzly.android.db.OrgzlyDatabase/158.json
+++ b/app/schemas/com.orgzly.android.db.OrgzlyDatabase/158.json
@@ -1,0 +1,1497 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 158,
+    "identityHash": "19deede919fc9bb3be197b68840276e3",
+    "entities": [
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `title` TEXT, `mtime` INTEGER, `is_dummy` INTEGER NOT NULL, `is_deleted` INTEGER, `preface` TEXT, `is_indented` INTEGER, `used_encoding` TEXT, `detected_encoding` TEXT, `selected_encoding` TEXT, `sync_status` TEXT, `last_sync_action_result` TEXT, `last_sync_action_timestamp` INTEGER, `is_modified` INTEGER NOT NULL, `last_action_type` TEXT, `last_action_message` TEXT, `last_action_timestamp` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mtime",
+            "columnName": "mtime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isDummy",
+            "columnName": "is_dummy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "preface",
+            "columnName": "preface",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isIndented",
+            "columnName": "is_indented",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "usedEncoding",
+            "columnName": "used_encoding",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "detectedEncoding",
+            "columnName": "detected_encoding",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "selectedEncoding",
+            "columnName": "selected_encoding",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSyncActionResult",
+            "columnName": "last_sync_action_result",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSyncActionTimestamp",
+            "columnName": "last_sync_action_timestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isModified",
+            "columnName": "is_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAction.type",
+            "columnName": "last_action_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastAction.message",
+            "columnName": "last_action_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastAction.timestamp",
+            "columnName": "last_action_timestamp",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_books_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_books_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_id` INTEGER NOT NULL, `repo_id` INTEGER NOT NULL, PRIMARY KEY(`book_id`), FOREIGN KEY(`book_id`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`repo_id`) REFERENCES `repos`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoId",
+            "columnName": "repo_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_links_repo_id",
+            "unique": false,
+            "columnNames": [
+              "repo_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_links_repo_id` ON `${TABLE_NAME}` (`repo_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "repos",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "repo_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_properties",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`book_id`, `name`), FOREIGN KEY(`book_id`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_id",
+            "name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_properties_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_properties_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_book_properties_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_properties_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_book_properties_value",
+            "unique": false,
+            "columnNames": [
+              "value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_properties_value` ON `${TABLE_NAME}` (`value`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_syncs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`book_id` INTEGER NOT NULL, `versioned_rook_id` INTEGER NOT NULL, PRIMARY KEY(`book_id`), FOREIGN KEY(`book_id`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`versioned_rook_id`) REFERENCES `versioned_rooks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionedRookId",
+            "columnName": "versioned_rook_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_syncs_versioned_rook_id",
+            "unique": false,
+            "columnNames": [
+              "versioned_rook_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_syncs_versioned_rook_id` ON `${TABLE_NAME}` (`versioned_rook_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "versioned_rooks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "versioned_rook_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "db_repo_books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `repo_url` TEXT NOT NULL, `url` TEXT NOT NULL, `revision` TEXT NOT NULL, `mtime` INTEGER NOT NULL, `content` TEXT NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoUrl",
+            "columnName": "repo_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revision",
+            "columnName": "revision",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtime",
+            "columnName": "mtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_db_repo_books_repo_url_url",
+            "unique": true,
+            "columnNames": [
+              "repo_url",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_db_repo_books_repo_url_url` ON `${TABLE_NAME}` (`repo_url`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `is_cut` INTEGER NOT NULL, `created_at` INTEGER, `title` TEXT NOT NULL, `tags` TEXT, `state` TEXT, `priority` TEXT, `content` TEXT, `content_line_count` INTEGER NOT NULL, `scheduled_range_id` INTEGER, `deadline_range_id` INTEGER, `closed_range_id` INTEGER, `clock_range_id` INTEGER, `book_id` INTEGER NOT NULL, `lft` INTEGER NOT NULL, `rgt` INTEGER NOT NULL, `level` INTEGER NOT NULL, `parent_id` INTEGER NOT NULL, `folded_under_id` INTEGER NOT NULL, `is_folded` INTEGER NOT NULL, `descendants_count` INTEGER NOT NULL, FOREIGN KEY(`book_id`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`scheduled_range_id`) REFERENCES `org_ranges`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`deadline_range_id`) REFERENCES `org_ranges`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`closed_range_id`) REFERENCES `org_ranges`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCut",
+            "columnName": "is_cut",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentLineCount",
+            "columnName": "content_line_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduledRangeId",
+            "columnName": "scheduled_range_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deadlineRangeId",
+            "columnName": "deadline_range_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "closedRangeId",
+            "columnName": "closed_range_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "clockRangeId",
+            "columnName": "clock_range_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "position.bookId",
+            "columnName": "book_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position.lft",
+            "columnName": "lft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position.rgt",
+            "columnName": "rgt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position.level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position.parentId",
+            "columnName": "parent_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position.foldedUnderId",
+            "columnName": "folded_under_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position.isFolded",
+            "columnName": "is_folded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position.descendantsCount",
+            "columnName": "descendants_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_notes_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_notes_tags",
+            "unique": false,
+            "columnNames": [
+              "tags"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_tags` ON `${TABLE_NAME}` (`tags`)"
+          },
+          {
+            "name": "index_notes_content",
+            "unique": false,
+            "columnNames": [
+              "content"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_content` ON `${TABLE_NAME}` (`content`)"
+          },
+          {
+            "name": "index_notes_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_notes_is_cut",
+            "unique": false,
+            "columnNames": [
+              "is_cut"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_is_cut` ON `${TABLE_NAME}` (`is_cut`)"
+          },
+          {
+            "name": "index_notes_lft",
+            "unique": false,
+            "columnNames": [
+              "lft"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_lft` ON `${TABLE_NAME}` (`lft`)"
+          },
+          {
+            "name": "index_notes_rgt",
+            "unique": false,
+            "columnNames": [
+              "rgt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_rgt` ON `${TABLE_NAME}` (`rgt`)"
+          },
+          {
+            "name": "index_notes_is_folded",
+            "unique": false,
+            "columnNames": [
+              "is_folded"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_is_folded` ON `${TABLE_NAME}` (`is_folded`)"
+          },
+          {
+            "name": "index_notes_folded_under_id",
+            "unique": false,
+            "columnNames": [
+              "folded_under_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_folded_under_id` ON `${TABLE_NAME}` (`folded_under_id`)"
+          },
+          {
+            "name": "index_notes_parent_id",
+            "unique": false,
+            "columnNames": [
+              "parent_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_parent_id` ON `${TABLE_NAME}` (`parent_id`)"
+          },
+          {
+            "name": "index_notes_descendants_count",
+            "unique": false,
+            "columnNames": [
+              "descendants_count"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_descendants_count` ON `${TABLE_NAME}` (`descendants_count`)"
+          },
+          {
+            "name": "index_notes_scheduled_range_id",
+            "unique": false,
+            "columnNames": [
+              "scheduled_range_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_scheduled_range_id` ON `${TABLE_NAME}` (`scheduled_range_id`)"
+          },
+          {
+            "name": "index_notes_deadline_range_id",
+            "unique": false,
+            "columnNames": [
+              "deadline_range_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_deadline_range_id` ON `${TABLE_NAME}` (`deadline_range_id`)"
+          },
+          {
+            "name": "index_notes_closed_range_id",
+            "unique": false,
+            "columnNames": [
+              "closed_range_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notes_closed_range_id` ON `${TABLE_NAME}` (`closed_range_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "org_ranges",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "scheduled_range_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "org_ranges",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "deadline_range_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "org_ranges",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "closed_range_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "note_ancestors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`note_id` INTEGER NOT NULL, `book_id` INTEGER NOT NULL, `ancestor_note_id` INTEGER NOT NULL, PRIMARY KEY(`book_id`, `note_id`, `ancestor_note_id`), FOREIGN KEY(`book_id`) REFERENCES `books`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`note_id`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`ancestor_note_id`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ancestorNoteId",
+            "columnName": "ancestor_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "book_id",
+            "note_id",
+            "ancestor_note_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_note_ancestors_book_id",
+            "unique": false,
+            "columnNames": [
+              "book_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_ancestors_book_id` ON `${TABLE_NAME}` (`book_id`)"
+          },
+          {
+            "name": "index_note_ancestors_note_id",
+            "unique": false,
+            "columnNames": [
+              "note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_ancestors_note_id` ON `${TABLE_NAME}` (`note_id`)"
+          },
+          {
+            "name": "index_note_ancestors_ancestor_note_id",
+            "unique": false,
+            "columnNames": [
+              "ancestor_note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_ancestors_ancestor_note_id` ON `${TABLE_NAME}` (`ancestor_note_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "book_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "note_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ancestor_note_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "note_properties",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`note_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`note_id`, `position`), FOREIGN KEY(`note_id`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "note_id",
+            "position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_note_properties_note_id",
+            "unique": false,
+            "columnNames": [
+              "note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_properties_note_id` ON `${TABLE_NAME}` (`note_id`)"
+          },
+          {
+            "name": "index_note_properties_position",
+            "unique": false,
+            "columnNames": [
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_properties_position` ON `${TABLE_NAME}` (`position`)"
+          },
+          {
+            "name": "index_note_properties_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_properties_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_note_properties_value",
+            "unique": false,
+            "columnNames": [
+              "value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_properties_value` ON `${TABLE_NAME}` (`value`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "note_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "note_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`note_id` INTEGER NOT NULL, `org_range_id` INTEGER NOT NULL, PRIMARY KEY(`note_id`, `org_range_id`), FOREIGN KEY(`note_id`) REFERENCES `notes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`org_range_id`) REFERENCES `org_ranges`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orgRangeId",
+            "columnName": "org_range_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "note_id",
+            "org_range_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_note_events_note_id",
+            "unique": false,
+            "columnNames": [
+              "note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_events_note_id` ON `${TABLE_NAME}` (`note_id`)"
+          },
+          {
+            "name": "index_note_events_org_range_id",
+            "unique": false,
+            "columnNames": [
+              "org_range_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_note_events_org_range_id` ON `${TABLE_NAME}` (`org_range_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "notes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "note_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "org_ranges",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "org_range_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "org_ranges",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `string` TEXT NOT NULL, `start_timestamp_id` INTEGER NOT NULL, `end_timestamp_id` INTEGER, `difference` INTEGER, FOREIGN KEY(`start_timestamp_id`) REFERENCES `org_timestamps`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`end_timestamp_id`) REFERENCES `org_timestamps`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "string",
+            "columnName": "string",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimestampId",
+            "columnName": "start_timestamp_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimestampId",
+            "columnName": "end_timestamp_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "difference",
+            "columnName": "difference",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_org_ranges_string",
+            "unique": true,
+            "columnNames": [
+              "string"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_org_ranges_string` ON `${TABLE_NAME}` (`string`)"
+          },
+          {
+            "name": "index_org_ranges_start_timestamp_id",
+            "unique": false,
+            "columnNames": [
+              "start_timestamp_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_org_ranges_start_timestamp_id` ON `${TABLE_NAME}` (`start_timestamp_id`)"
+          },
+          {
+            "name": "index_org_ranges_end_timestamp_id",
+            "unique": false,
+            "columnNames": [
+              "end_timestamp_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_org_ranges_end_timestamp_id` ON `${TABLE_NAME}` (`end_timestamp_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "org_timestamps",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "start_timestamp_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "org_timestamps",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "end_timestamp_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "org_timestamps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `string` TEXT NOT NULL, `is_active` INTEGER NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `day` INTEGER NOT NULL, `hour` INTEGER, `minute` INTEGER, `second` INTEGER, `end_hour` INTEGER, `end_minute` INTEGER, `end_second` INTEGER, `repeater_type` INTEGER, `repeater_value` INTEGER, `repeater_unit` INTEGER, `habit_deadline_value` INTEGER, `habit_deadline_unit` INTEGER, `delay_type` INTEGER, `delay_value` INTEGER, `delay_unit` INTEGER, `timestamp` INTEGER NOT NULL, `end_timestamp` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "string",
+            "columnName": "string",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hour",
+            "columnName": "hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "minute",
+            "columnName": "minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "second",
+            "columnName": "second",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endHour",
+            "columnName": "end_hour",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endMinute",
+            "columnName": "end_minute",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endSecond",
+            "columnName": "end_second",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeaterType",
+            "columnName": "repeater_type",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeaterValue",
+            "columnName": "repeater_value",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "repeaterUnit",
+            "columnName": "repeater_unit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "habitDeadlineValue",
+            "columnName": "habit_deadline_value",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "habitDeadlineUnit",
+            "columnName": "habit_deadline_unit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "delayType",
+            "columnName": "delay_type",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "delayValue",
+            "columnName": "delay_value",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "delayUnit",
+            "columnName": "delay_unit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimestamp",
+            "columnName": "end_timestamp",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_org_timestamps_string",
+            "unique": true,
+            "columnNames": [
+              "string"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_org_timestamps_string` ON `${TABLE_NAME}` (`string`)"
+          },
+          {
+            "name": "index_org_timestamps_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_org_timestamps_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_org_timestamps_end_timestamp",
+            "unique": false,
+            "columnNames": [
+              "end_timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_org_timestamps_end_timestamp` ON `${TABLE_NAME}` (`end_timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "repos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` INTEGER NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_repos_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_repos_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rooks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `repo_id` INTEGER NOT NULL, `rook_url_id` INTEGER NOT NULL, FOREIGN KEY(`repo_id`) REFERENCES `repos`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`rook_url_id`) REFERENCES `rook_urls`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repoId",
+            "columnName": "repo_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rookUrlId",
+            "columnName": "rook_url_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rooks_repo_id_rook_url_id",
+            "unique": true,
+            "columnNames": [
+              "repo_id",
+              "rook_url_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_rooks_repo_id_rook_url_id` ON `${TABLE_NAME}` (`repo_id`, `rook_url_id`)"
+          },
+          {
+            "name": "index_rooks_rook_url_id",
+            "unique": false,
+            "columnNames": [
+              "rook_url_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rooks_rook_url_id` ON `${TABLE_NAME}` (`rook_url_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "repos",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "repo_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "rook_urls",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rook_url_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "rook_urls",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rook_urls_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_rook_urls_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "searches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `query` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "versioned_rooks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `rook_id` INTEGER NOT NULL, `rook_revision` TEXT NOT NULL, `rook_mtime` INTEGER NOT NULL, FOREIGN KEY(`rook_id`) REFERENCES `rooks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rookId",
+            "columnName": "rook_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rookRevision",
+            "columnName": "rook_revision",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rookMtime",
+            "columnName": "rook_mtime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_versioned_rooks_rook_id",
+            "unique": false,
+            "columnNames": [
+              "rook_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_versioned_rooks_rook_id` ON `${TABLE_NAME}` (`rook_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "rooks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "rook_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "app_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `name` TEXT NOT NULL, `message` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_logs_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_logs_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_app_logs_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_logs_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '19deede919fc9bb3be197b68840276e3')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/orgzly/android/data/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/data/DatabaseMigrationTest.kt
@@ -1,0 +1,83 @@
+package com.orgzly.android.data
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.orgzly.android.OrgzlyTest // Make sure this is the correct base class if needed
+import com.orgzly.android.db.OrgzlyDatabase
+import com.orgzly.android.db.entity.SyncResult
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class DatabaseMigrationTest : OrgzlyTest() { // Extend OrgzlyTest as per plan
+
+    private val TEST_DB = "migration-test"
+    private val DB_NAME = OrgzlyDatabase.NAME // Use the correct constant name from OrgzlyDatabase
+
+    // Rule for MigrationTestHelper - Add this back
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        OrgzlyDatabase::class.java.canonicalName,
+        FrameworkSQLiteOpenHelperFactory()
+    )
+
+    // Removed @Before and @After setup/teardown that might duplicate OrgzlyTest
+
+    /**
+     * Test migration from version 157 to 158 adds sync action result columns.
+     */
+    @Test
+    @Throws(IOException::class) // Add Throws annotation for helper methods
+    fun migrate157To158_addsSyncActionColumns() {
+        // 1. Create V157 database using MigrationTestHelper
+        var db = helper.createDatabase(TEST_DB, 157).apply {
+            // 2. Setup: Insert v157-like data, including the NOT NULL column
+            execSQL("INSERT INTO books (id, name, is_dummy, is_modified) VALUES (1, 'Test Book For Migration', 0, 0)")
+            close()
+        }
+
+        // 3. Run migration to V158 using MigrationTestHelper
+        // Pass the static migration from OrgzlyDatabase
+        db = helper.runMigrationsAndValidate(TEST_DB, 158, true, OrgzlyDatabase.MIGRATION_157_158)
+
+        // 4. Verify columns exist and default values are NULL using raw query on migrated DB
+        val cursor = db.query("SELECT last_sync_action_result, last_sync_action_timestamp FROM books WHERE id = 1")
+        assertTrue("Cursor should contain results", cursor.moveToFirst())
+        // Check column existence implicitly by querying. Check default NULL value.
+        assertNull("Default last_sync_action_result should be null", cursor.getString(cursor.getColumnIndexOrThrow("last_sync_action_result")))
+        assertTrue("Default last_sync_action_timestamp should be null", cursor.isNull(cursor.getColumnIndexOrThrow("last_sync_action_timestamp")))
+        cursor.close()
+
+        // Close the SupportSQLiteDatabase handle from the helper
+        db.close()
+
+        // 5. Optional: Verify DAO update works on migrated schema
+        // Re-open the database with Room to get DAO access after migration
+        val roomDb = OrgzlyDatabase.forFile(InstrumentationRegistry.getInstrumentation().targetContext, TEST_DB) // Use TEST_DB name
+        val bookDao = roomDb.book()
+        val testTimestamp = System.currentTimeMillis()
+        val updateCount = bookDao.updateLastSyncActionResult(1, SyncResult.SUCCESS, testTimestamp)
+        assertEquals("DAO update should affect 1 row", 1, updateCount)
+
+        // Re-query via DAO to check if update worked
+        val book = bookDao.get(1)
+        assertNotNull("Book should be found", book)
+        assertEquals(SyncResult.SUCCESS, book?.lastSyncActionResult)
+        assertEquals(testTimestamp, book?.lastSyncActionTimestamp)
+
+        // Close the Room database instance
+        roomDb.close()
+    }
+
+} 

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -257,7 +257,7 @@ class DataRepository @Inject constructor(
         return db.book().get(id) ?: throw IllegalStateException("Book with ID $id not found")
     }
 
-    fun getBookLiveData(id: Long): LiveData<Book> {
+    fun getBookLiveData(id: Long): LiveData<Book?> {
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, id)
         return db.book().getLiveData(id)
     }

--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -90,8 +90,10 @@ class DataRepository @Inject constructor(
             val loadedBook = loadBookFromRepo(book.linkRepo.id, book.linkRepo.type, book.linkRepo.url, repoRelativePath)
 
             setBookLastActionAndSyncStatus(loadedBook!!.book.id, BookAction.forNow(
-                    BookAction.Type.INFO,
-                    resources.getString(R.string.force_loaded_from_uri, loadedBook.syncedTo?.uri)))
+                BookAction.Type.INFO,
+                resources.getString(R.string.force_loaded_from_uri, loadedBook.syncedTo?.uri)))
+            // Update sync action result on success
+            updateLastSyncActionResult(loadedBook.book.id, SyncResult.SUCCESS, System.currentTimeMillis())
 
         } catch (e: Exception) {
             e.printStackTrace()
@@ -99,6 +101,8 @@ class DataRepository @Inject constructor(
             val msg = resources.getString(R.string.force_loading_failed, e.localizedMessage)
 
             setBookLastActionAndSyncStatus(bookId, BookAction.forNow(BookAction.Type.ERROR, msg))
+            // Update sync action result on error
+            updateLastSyncActionResult(bookId, SyncResult.ERROR, System.currentTimeMillis())
 
             throw IOException(msg)
         }
@@ -123,8 +127,10 @@ class DataRepository @Inject constructor(
             val savedBook = getBookView(bookId)
 
             setBookLastActionAndSyncStatus(bookId, BookAction.forNow(
-                    BookAction.Type.INFO,
-                    resources.getString(R.string.force_saved_to_uri, savedBook?.syncedTo?.uri)))
+                BookAction.Type.INFO,
+                resources.getString(R.string.force_saved_to_uri, savedBook?.syncedTo?.uri)))
+            // Update sync action result on success
+            updateLastSyncActionResult(bookId, SyncResult.SUCCESS, System.currentTimeMillis())
 
         } catch (e: Exception) {
             e.printStackTrace()
@@ -134,6 +140,8 @@ class DataRepository @Inject constructor(
             if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, "Updating status for $bookId")
 
             setBookLastActionAndSyncStatus(bookId, BookAction.forNow(BookAction.Type.ERROR, msg))
+            // Update sync action result on error
+            updateLastSyncActionResult(bookId, SyncResult.ERROR, System.currentTimeMillis())
 
             throw IOException(msg)
         }
@@ -2552,5 +2560,16 @@ class DataRepository @Inject constructor(
         private val TAG = DataRepository::class.java.name
 
         const val GETTING_STARTED_NOTEBOOK_RESOURCE_ID = R.raw.orgzly_getting_started
+    }
+
+    /**
+     * Updates the last sync action result and timestamp for a book.
+     *
+     * @param bookId The ID of the book to update.
+     * @param result The result of the sync operation (SUCCESS or ERROR).
+     * @param timestamp The timestamp of the sync operation.
+     */
+    fun updateLastSyncActionResult(bookId: Long, result: SyncResult, timestamp: Long) {
+        db.book().updateLastSyncActionResult(bookId, result, timestamp)
     }
 }

--- a/app/src/main/java/com/orgzly/android/db/OrgzlyDatabase.kt
+++ b/app/src/main/java/com/orgzly/android/db/OrgzlyDatabase.kt
@@ -53,6 +53,7 @@ import com.orgzly.android.util.LogUtils
 import com.orgzly.org.OrgActiveTimestamps
 import com.orgzly.org.datetime.OrgDateTime
 import java.util.Calendar
+import androidx.annotation.VisibleForTesting
 
 @Database(
         entities = [
@@ -75,7 +76,7 @@ import java.util.Calendar
             AppLog::class
         ],
 
-        version = 157
+        version = 158
 )
 @TypeConverters(com.orgzly.android.db.TypeConverters::class)
 abstract class OrgzlyDatabase : RoomDatabase() {
@@ -151,7 +152,8 @@ abstract class OrgzlyDatabase : RoomDatabase() {
                             MIGRATION_153_154,
                             MIGRATION_154_155,
                             MIGRATION_155_156,
-                            MIGRATION_156_157
+                            MIGRATION_156_157,
+                            MIGRATION_157_158
                     )
                     .addCallback(object : Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {
@@ -609,6 +611,14 @@ abstract class OrgzlyDatabase : RoomDatabase() {
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_book_properties_book_id` ON `book_properties` (`book_id`)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_book_properties_name` ON `book_properties` (`name`)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_book_properties_value` ON `book_properties` (`value`)")
+            }
+        }
+
+        // Make migration internal to be accessible by tests
+        internal val MIGRATION_157_158 = object : Migration(157, 158) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE books ADD COLUMN last_sync_action_result TEXT")
+                db.execSQL("ALTER TABLE books ADD COLUMN last_sync_action_timestamp INTEGER DEFAULT NULL")
             }
         }
     }

--- a/app/src/main/java/com/orgzly/android/db/dao/BookDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/BookDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Query
 import androidx.room.Update
 import com.orgzly.android.db.entity.Book
 import com.orgzly.android.db.entity.BookAction
+import com.orgzly.android.db.entity.SyncResult
 
 
 @Dao
@@ -37,6 +38,9 @@ abstract class BookDao : BaseDao<Book> {
 
     @Query("UPDATE books SET last_action_type = :type, last_action_message = :message, last_action_timestamp = :timestamp, sync_status = :status WHERE id = :id")
     abstract fun updateLastActionAndSyncStatus(id: Long, type: BookAction.Type, message: String, timestamp: Long, status: String?): Int
+
+    @Query("UPDATE books SET last_sync_action_result = :syncResult, last_sync_action_timestamp = :timestamp WHERE id = :id")
+    abstract fun updateLastSyncActionResult(id: Long, syncResult: SyncResult, timestamp: Long): Int
 
     @Query("UPDATE books SET last_action_type = :type, last_action_message = :message, last_action_timestamp = :timestamp, sync_status = :status WHERE last_action_type = :whereType")
     abstract fun updateStatusToCanceled(whereType: BookAction.Type, type: BookAction.Type, message: String, timestamp: Long, status: String?): Int

--- a/app/src/main/java/com/orgzly/android/db/dao/BookDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/BookDao.kt
@@ -18,7 +18,7 @@ abstract class BookDao : BaseDao<Book> {
     abstract fun get(name: String): Book?
 
     @Query("SELECT * FROM books WHERE id = :id")
-    abstract fun getLiveData(id: Long): LiveData<Book> // null not allowed, use List
+    abstract fun getLiveData(id: Long): LiveData<Book?>
 
     @Query("SELECT * FROM books WHERE last_action_type = :type")
     abstract fun getWithActionType(type: BookAction.Type): List<Book>

--- a/app/src/main/java/com/orgzly/android/db/entity/Book.kt
+++ b/app/src/main/java/com/orgzly/android/db/entity/Book.kt
@@ -47,6 +47,12 @@ data class Book constructor(
         @Embedded(prefix = "last_action_")
         val lastAction: BookAction? = null,
 
+        @ColumnInfo(name = "last_sync_action_result")
+        var lastSyncActionResult: SyncResult? = null,
+
+        @ColumnInfo(name = "last_sync_action_timestamp")
+        var lastSyncActionTimestamp: Long? = null,
+
         @ColumnInfo(name = "is_modified")
         val isModified: Boolean = false
 ) {

--- a/app/src/main/java/com/orgzly/android/db/entity/SyncResult.kt
+++ b/app/src/main/java/com/orgzly/android/db/entity/SyncResult.kt
@@ -1,0 +1,18 @@
+package com.orgzly.android.db.entity
+
+/**
+ * Represents the outcome/result of the last completed synchronization *action* for a Book.
+ * This is distinct from BookSyncStatus which determines the *next* sync action needed.
+ */
+enum class SyncResult {
+    /** Sync action completed successfully (changes might have been made or not). */
+    SUCCESS,
+
+    // NO_CHANGE removed, considered part of SUCCESS
+
+    /** Sync action failed due to an error (network, credentials, file access, etc.). */
+    ERROR,
+
+    /** Sync action resulted in a conflict state (e.g., both local and remote modified). */
+    CONFLICT
+} 

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -1069,6 +1069,14 @@ public class AppPreferences {
         return getStateSharedPreferences(context).getLong(key, 0L);
     }
 
+    public static boolean displaySyncStatusOnNote(Context context) {
+        String key = context.getResources().getString(R.string.pref_key_display_sync_status);
+        return getDefaultSharedPreferences(context).getBoolean(
+                key,
+                false
+        );
+    }
+
     /*
      * ReminderWorker
      */

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
@@ -428,7 +428,6 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
                 }
                 .setNegativeButton(R.string.cancel) { _, _ -> }
                 .show()
-
         })
 
         viewModel.bookChangeRequestEvent.observeSingle(viewLifecycleOwner, Observer { books ->
@@ -443,6 +442,12 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
 
         viewModel.snackBarMessage.observeSingle(viewLifecycleOwner, Observer { resId ->
             activity?.showSnackbar(resId)
+        })
+
+        // Observe the last sync status text and update the toolbar subtitle
+        viewModel.lastSyncStatusText.observe(viewLifecycleOwner, Observer { syncStatus ->
+            // Set the subtitle of the Toolbar. If syncStatus is null or empty, the subtitle will be cleared.
+            binding.topToolbar.subtitle = syncStatus
         })
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -739,6 +739,11 @@
     <string name="orgzlyignore_file">Ignore pattern filename</string>
     <string name="orgzlyignore_file_desc">The path of the file containing the ignore patterns relative to the repository root.</string>
     <string name="copied_link">Copied link</string>
-    <string name="synced_prefix">Synced: %s</string>
-    <string name="never_synced">Never synced</string>
+    
+    <!-- Sync status for NoteViewModel -->
+    <string name="sync_status_synced">Synced: %1$s</string>
+    <string name="sync_status_error">Sync error: %1$s</string>
+    <string name="sync_status_conflict">Sync conflict</string>
+    <string name="sync_status_never">Never synced</string>
+    <string name="unknown_time">unknown time</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,6 +505,10 @@
     <string name="pref_title_repo_update_sync">Repositories modified (not implemented yet)</string>
     <string name="pref_summary_repo_update_sync">Sync whenever an update in repositories is detected</string>
 
+    <string name="pref_key_display_sync_status" translatable="false">pref_display_sync_status</string>
+    <string name="pref_display_sync_status_title">Display sync status on a note</string>
+    <string name="pref_display_sync_status_summary">Status and timestamp of the last sync action of the notebook.</string>
+    
     <string name="not_modified">Not modified</string>
 
     <string name="notes_count_zero">Contains no notes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -506,7 +506,7 @@
     <string name="pref_summary_repo_update_sync">Sync whenever an update in repositories is detected</string>
 
     <string name="pref_key_display_sync_status" translatable="false">pref_display_sync_status</string>
-    <string name="pref_display_sync_status_title">Display sync status on a note</string>
+    <string name="pref_display_sync_status_title">Display sync status when editing</string>
     <string name="pref_display_sync_status_summary">Status and timestamp of the last sync action of the notebook.</string>
     
     <string name="not_modified">Not modified</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -738,4 +738,7 @@
 
     <string name="orgzlyignore_file">Ignore pattern filename</string>
     <string name="orgzlyignore_file_desc">The path of the file containing the ignore patterns relative to the repository root.</string>
+    <string name="copied_link">Copied link</string>
+    <string name="synced_prefix">Synced: %s</string>
+    <string name="never_synced">Never synced</string>
 </resources>

--- a/app/src/main/res/xml/prefs_screen_sync.xml
+++ b/app/src/main/res/xml/prefs_screen_sync.xml
@@ -73,5 +73,11 @@
             android:title="@string/org_file_format"
             android:summary="@string/org_file_format_summary">
         </androidx.preference.PreferenceScreen>
+
+        <SwitchPreference
+            android:key="@string/pref_key_display_sync_status"
+            android:title="@string/pref_display_sync_status_title"
+            android:summary="@string/pref_display_sync_status_summary"
+            android:defaultValue="false"/>
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Adding a synced time to the toolbar on a NoteFragment. Message updates when a resync is performed. 
![image](https://github.com/user-attachments/assets/05b43192-98d3-4265-8904-ad72e98dffa1)

The purpose of this is to remind people that their book might be outdated so they can perform sync themselves or informs them sync has just been performed so they can have a peace of mind. 

Follow-ups: 
1. Better message: something like "Synced just now", "Haven't synced for 3 hours", "Merge conflict 10 minutes ago", etc. 
2. Add a call-to-action button next to the message such as "sync", "upload and download" (when merge conflict). 
3. Update the sync functionality to support syncing of one book (for API usage purposes), and do auto syncing when a note is opened. 


