### PR TITLE
[quick fix] Fixed a sorting bug where minutes are not impacting sorting order

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/AgendaSortingTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/AgendaSortingTest.kt
@@ -63,6 +63,9 @@ class AgendaSortingTest : OrgzlyTest() {
             
             * Note C
             SCHEDULED: <${getToday()} 11:15>
+            
+            * Note D
+            SCHEDULED: <${getToday()} 14:15>
             """.trimIndent()
         )
 
@@ -79,8 +82,39 @@ class AgendaSortingTest : OrgzlyTest() {
         // Note C (11:15) should be second
         onItemInAgenda(2, R.id.item_head_title_view).check(matches(withText(containsString("Note C"))))
         
+        // Note D (14:15) should be third
+        onItemInAgenda(3, R.id.item_head_title_view).check(matches(withText(containsString("Note D"))))
+
         // Note B (14:30) should be third
-        onItemInAgenda(3, R.id.item_head_title_view).check(matches(withText(containsString("Note B"))))
+        onItemInAgenda(4, R.id.item_head_title_view).check(matches(withText(containsString("Note B"))))
+    }
+
+    @Test
+    fun testMidnightTaskSorting() {
+        // Set up test data with different scheduled times on the same day
+        testUtils.setupBook(
+            "book-one",
+            """
+            * Note A
+            SCHEDULED: <${getToday()}>
+            
+            * Note B
+            SCHEDULED: <${getToday()} 00:00>
+            """.trimIndent()
+        )
+
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+
+        // Search for agenda items for that specific day
+        searchForTextCloseKeyboard("ad.1")
+
+        // First item (position 0) is the Date Header
+
+        // Note B (00:00) should be first
+        onItemInAgenda(1, R.id.item_head_title_view).check(matches(withText(containsString("Note B"))))
+
+        // Note A (no time in day) should be second
+        onItemInAgenda(2, R.id.item_head_title_view).check(matches(withText(containsString("Note A"))))
     }
 
     @Test

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaItem.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaItem.kt
@@ -6,6 +6,21 @@ import org.joda.time.DateTime
 
 private const val MILLIS_IN_DAY = 24 * 60 * 60 * 1000L
 
+/**
+ * Calculates the milliseconds elapsed since the start of the day for a given timestamp.
+ * Returns null if the input timestamp is null.
+ */
+private fun calculateTimeInDay(timestamp: Long?): Long? {
+    return timestamp?.let { tsMillis ->
+        // Create a Joda-Time DateTime object from the timestamp
+        val dateTime = DateTime(tsMillis)
+        // Get the timestamp for the start of that same day (midnight)
+        val startOfDayMillis = dateTime.withTimeAtStartOfDay().millis
+        // Calculate the difference
+        tsMillis - startOfDayMillis
+    }
+}
+
 sealed class AgendaItem(open val id: Long) {
     data class Overdue(override val id: Long) : AgendaItem(id)
 
@@ -20,12 +35,17 @@ sealed class AgendaItem(open val id: Long) {
 
         companion object {
             fun compareByTimeInDay(a: Note, b: Note): Int {
-                // If both notes are missing the time, then it will keep the original order
+                // use hour as a signal for whether this time has a time-in-day (e.g. HH:MM part)
+                // We can't use timestamp to tell this, because <04-17 00:00> has a same timestamp as <04-17>
+                // If both notes are missing the hour, then it will keep the original order
                 if (a.hour == null && b.hour == null) return 0
                 if (a.hour == null) return 1  // Null hour go last
                 if (b.hour == null) return -1 // Null timestamps go last
 
-                return a.hour - b.hour
+                if (a.timeInDay == null && b.timeInDay == null) return 0
+                if (a.timeInDay == null) return 1
+                if (b.timeInDay == null) return -1
+                return a.timeInDay.compareTo(b.timeInDay)
             }
             fun compareByTime(a: Note, b: Note): Int {
                 // First compare timestamps
@@ -54,6 +74,16 @@ sealed class AgendaItem(open val id: Long) {
             TimeType.DEADLINE -> note.deadlineTimeHour
             TimeType.EVENT -> note.eventHour
             else -> null
+        }
+
+        // Calculate milliseconds since start of the day, null if time or start-of-day is missing
+        // we cannot trust fooStartOfDay because it can be a different day from than the foo Timestamp
+        // for repeating tasks. Therefore, we use calculateTimeInDay instead
+        private val timeInDay: Long? = when (timeType) {
+            TimeType.SCHEDULED -> calculateTimeInDay(note.scheduledTimeTimestamp)
+            TimeType.DEADLINE -> calculateTimeInDay(note.deadlineTimeTimestamp)
+            TimeType.EVENT -> calculateTimeInDay(note.eventTimestamp)
+            else -> 0
         }
     }
 }


### PR DESCRIPTION
Previously it was using hours to sort the agenda items, now using timestamp, so that it can include minutes in the sorting logic. 