### PR TITLE
Pre Notifications for reminders

### DIFF
--- a/app/src/main/java/com/orgzly/android/data/DataRepository.kt
+++ b/app/src/main/java/com/orgzly/android/data/DataRepository.kt
@@ -1369,6 +1369,10 @@ class DataRepository @Inject constructor(
             .distinctBy { it.lowercase() }
     }
 
+    fun getNoteProperties(noteId: Long, name: String): List<NoteProperty> {
+        return db.noteProperty().get(noteId, name)
+    }
+
     private fun setNoteProperty(noteId: Long, name: String, value: String) {
         db.noteProperty().upsert(noteId, name, value)
     }

--- a/app/src/main/java/com/orgzly/android/db/dao/ReminderTimeDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/ReminderTimeDao.kt
@@ -2,6 +2,8 @@ package com.orgzly.android.db.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import com.orgzly.android.App
+import com.orgzly.android.prefs.AppPreferences
 
 @Dao
 interface ReminderTimeDao {
@@ -31,7 +33,7 @@ interface ReminderTimeDao {
         JOIN org_timestamps t ON (r.start_timestamp_id = t.id )
         JOIN notes n ON (r.id = n.scheduled_range_id)
         JOIN books b ON (b.id = n.book_id)
-        JOIN note_properties p ON (p.note_id = n.id AND p.name = "alert-periods")
+        JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
         WHERE t.is_active = 1
 
         UNION
@@ -50,7 +52,7 @@ interface ReminderTimeDao {
         JOIN org_timestamps t ON (r.start_timestamp_id = t.id )
         JOIN notes n ON (r.id = n.deadline_range_id)
         JOIN books b ON (b.id = n.book_id)
-        JOIN note_properties p ON (p.note_id = n.id AND p.name = "alert-periods")
+        JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
         WHERE t.is_active = 1
 
         UNION
@@ -70,9 +72,14 @@ interface ReminderTimeDao {
         JOIN org_timestamps t ON (t.id = r.start_timestamp_id)
         JOIN notes n ON (n.id = e.note_id)
         JOIN books b ON (b.id = n.book_id)
-        JOIN note_properties p ON (p.note_id = n.id AND p.name = "alert-periods")
+        JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
     """)
-    fun getAll(): List<NoteTime>
+    fun getAll(preNotifyProperty: String): List<NoteTime>
+
+    fun getAll(): List<NoteTime> {
+        return getAll(AppPreferences.preNotifyProperty(App.getAppContext()));
+    }
+
 
     companion object {
         const val SCHEDULED_TIME = 1

--- a/app/src/main/java/com/orgzly/android/db/dao/ReminderTimeDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/ReminderTimeDao.kt
@@ -16,7 +16,7 @@ interface ReminderTimeDao {
             var tags: String?,
             var timeType: Int,
             var orgTimestampString: String,
-            var orgPreAlerts: String)
+            var orgPreAlerts: String?)
 
     @Query("""
         SELECT
@@ -33,7 +33,7 @@ interface ReminderTimeDao {
         JOIN org_timestamps t ON (r.start_timestamp_id = t.id )
         JOIN notes n ON (r.id = n.scheduled_range_id)
         JOIN books b ON (b.id = n.book_id)
-        JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
+        LEFT JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
         WHERE t.is_active = 1
 
         UNION
@@ -52,7 +52,7 @@ interface ReminderTimeDao {
         JOIN org_timestamps t ON (r.start_timestamp_id = t.id )
         JOIN notes n ON (r.id = n.deadline_range_id)
         JOIN books b ON (b.id = n.book_id)
-        JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
+        LEFT JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
         WHERE t.is_active = 1
 
         UNION
@@ -72,7 +72,7 @@ interface ReminderTimeDao {
         JOIN org_timestamps t ON (t.id = r.start_timestamp_id)
         JOIN notes n ON (n.id = e.note_id)
         JOIN books b ON (b.id = n.book_id)
-        JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
+        LEFT JOIN note_properties p ON (p.note_id = n.id AND p.name = :preNotifyProperty)
     """)
     fun getAll(preNotifyProperty: String): List<NoteTime>
 

--- a/app/src/main/java/com/orgzly/android/db/dao/ReminderTimeDao.kt
+++ b/app/src/main/java/com/orgzly/android/db/dao/ReminderTimeDao.kt
@@ -13,7 +13,8 @@ interface ReminderTimeDao {
             var title: String,
             var tags: String?,
             var timeType: Int,
-            var orgTimestampString: String)
+            var orgTimestampString: String,
+            var orgPreAlerts: String)
 
     @Query("""
         SELECT
@@ -24,11 +25,13 @@ interface ReminderTimeDao {
         n.title as title,
         n.tags as tags,
         $SCHEDULED_TIME as timeType,
-        t.string as orgTimestampString
+        t.string as orgTimestampString,
+        p.value as orgPreAlerts
         FROM org_ranges r
         JOIN org_timestamps t ON (r.start_timestamp_id = t.id )
         JOIN notes n ON (r.id = n.scheduled_range_id)
         JOIN books b ON (b.id = n.book_id)
+        JOIN note_properties p ON (p.note_id = n.id AND p.name = "alert-periods")
         WHERE t.is_active = 1
 
         UNION
@@ -41,11 +44,13 @@ interface ReminderTimeDao {
         n.title as title,
         n.tags as tags,
         $DEADLINE_TIME as timeType,
-        t.string as orgTimestampString
+        t.string as orgTimestampString,
+        p.value as orgPreAlerts
         FROM org_ranges r
         JOIN org_timestamps t ON (r.start_timestamp_id = t.id )
         JOIN notes n ON (r.id = n.deadline_range_id)
         JOIN books b ON (b.id = n.book_id)
+        JOIN note_properties p ON (p.note_id = n.id AND p.name = "alert-periods")
         WHERE t.is_active = 1
 
         UNION
@@ -58,13 +63,14 @@ interface ReminderTimeDao {
         n.title as title,
         n.tags as tags,
         $EVENT_TIME as timeType,
-        t.string as orgTimestampString
+        t.string as orgTimestampString,
+        p.value as orgPreAlerts
         FROM note_events e
         JOIN org_ranges r ON (r.id = e.org_range_id)
         JOIN org_timestamps t ON (t.id = r.start_timestamp_id)
         JOIN notes n ON (n.id = e.note_id)
         JOIN books b ON (b.id = n.book_id)
-
+        JOIN note_properties p ON (p.note_id = n.id AND p.name = "alert-periods")
     """)
     fun getAll(): List<NoteTime>
 

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -788,6 +788,14 @@ public class AppPreferences {
                 context.getResources().getString(R.string.pref_default_pre_notify_property));
     }
 
+    public static String preNotifyFormat(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_pre_notify_format),
+                context.getResources().getString(R.string.pref_default_pre_notify_format));
+    }
+
+
+
     /*
      * Open note or book on link/breadcrumbs follow.
      */

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -788,14 +788,6 @@ public class AppPreferences {
                 context.getResources().getString(R.string.pref_default_pre_notify_property));
     }
 
-    public static String preNotifyFormat(Context context) {
-        return getDefaultSharedPreferences(context).getString(
-                context.getResources().getString(R.string.pref_key_pre_notify_format),
-                context.getResources().getString(R.string.pref_default_pre_notify_format));
-    }
-
-
-
     /*
      * Open note or book on link/breadcrumbs follow.
      */

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -780,6 +780,15 @@ public class AppPreferences {
     }
 
     /*
+     * The notification pre-notify keyword.
+     */
+    public static String preNotifyProperty(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_pre_notify_property),
+                context.getResources().getString(R.string.pref_default_pre_notify_property));
+    }
+
+    /*
      * Open note or book on link/breadcrumbs follow.
      */
 

--- a/app/src/main/java/com/orgzly/android/reminders/NoteReminders.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/NoteReminders.kt
@@ -30,14 +30,7 @@ object NoteReminders {
         intervalType: Int): List<NoteReminder> {
 
         val result: MutableList<NoteReminder> = ArrayList()
-        val format = AppPreferences.preNotifyFormat(context)
-        val isMinuteFormat = context.getResources().getString(R.string.pref_value_pre_notify_format_minutes) == format;
-
-        val deliminiter = if (isMinuteFormat) {
-            " "
-        } else {
-            ";"
-        }
+        val preNotifyParser = PreNotificationParser(context)
 
         for (noteTime in dataRepository.times()) {
             if (isRelevantNoteTime(context, noteTime)) {
@@ -58,28 +51,7 @@ object NoteReminders {
                     null
                 }
 
-                val preNotification = noteTime.orgPreAlerts
-
-                var periods = mutableSetOf(0)
-                if (preNotification.length > 0) {
-                    periods = (preNotification.split(deliminiter)
-                        .map {
-                            try {
-                                if (isMinuteFormat) {
-                                    it.toInt() * 1000 * 60
-                                } else {
-                                    Duration.parse(it.trim()).inWholeMilliseconds.toInt()
-                                }
-                            } catch (_: Exception) {
-                                0 // safely default to 0
-                            }
-                        }).toMutableSet()
-                }
-
-                // always notify at the actual reminder time
-                periods.add(0)
-
-                for (period in periods.sortedDescending()) {
+                for (period in preNotifyParser.parse(noteTime.orgPreAlerts)) {
                     var time = getFirstTime(
                         orgDateTime,
                         interval,

--- a/app/src/main/java/com/orgzly/android/reminders/NoteReminders.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/NoteReminders.kt
@@ -48,7 +48,7 @@ object NoteReminders {
                     null
                 }
 
-                for (period in preNotifyParser.parse(noteTime.orgPreAlerts)) {
+                for (period in preNotifyParser.parse(noteTime.orgPreAlerts ?: "")) {
                     var time = getFirstTime(
                         orgDateTime,
                         interval,

--- a/app/src/main/java/com/orgzly/android/reminders/NoteReminders.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/NoteReminders.kt
@@ -1,7 +1,6 @@
 package com.orgzly.android.reminders
 
 import android.content.Context
-import com.orgzly.R
 import com.orgzly.android.data.DataRepository
 import com.orgzly.android.db.dao.ReminderTimeDao
 import com.orgzly.android.db.dao.ReminderTimeDao.NoteTime
@@ -12,8 +11,6 @@ import com.orgzly.org.datetime.OrgInterval
 import org.joda.time.DateTime
 import org.joda.time.ReadableInstant
 import java.util.*
-import kotlin.time.Duration
-
 
 object NoteReminders {
     // private val TAG: String = NoteReminders::class.java.name
@@ -30,7 +27,7 @@ object NoteReminders {
         intervalType: Int): List<NoteReminder> {
 
         val result: MutableList<NoteReminder> = ArrayList()
-        val preNotifyParser = PreNotificationParser(context)
+        val preNotifyParser = PreNotificationParser()
 
         for (noteTime in dataRepository.times()) {
             if (isRelevantNoteTime(context, noteTime)) {

--- a/app/src/main/java/com/orgzly/android/reminders/PreNotificationParser.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/PreNotificationParser.kt
@@ -1,0 +1,60 @@
+package com.orgzly.android.reminders
+
+import android.content.Context
+import com.orgzly.R
+import com.orgzly.android.prefs.AppPreferences
+import kotlin.time.Duration
+
+/**
+ * Parse the pre-notfication property.
+ *
+ * The parser can be configured to accept two formats. If the format is
+ * [R.string.pref_value_pre_notify_format_minutes] the property value is parsed as
+ * a whitespace-separated list of minutes (float values allowed). An example would be `"60 30 5"`.
+ * Otherwise, the property is parsed as comma separated list of time interval strings
+ * such as `"1d, 1h, 30m, 5m 30s"` (see [kotlin.time.Duration.parse]).
+ *
+ * @param context The app context used to read the settings.
+ */
+class PreNotificationParser(context: Context) {
+    private val isMinuteFormat: Boolean
+    private val delimiter: String
+
+    init {
+        val format = AppPreferences.preNotifyFormat(context)
+        isMinuteFormat = context.getResources().getString(R.string.pref_value_pre_notify_format_minutes) == format;
+        delimiter = if (isMinuteFormat) {
+            " "
+        } else {
+            ";"
+        }
+    }
+
+    /**
+     * Parse a given string [value] into a list of list of time intervals in milliseconds
+     * sorted in descending order. For the format see [PreNotificationParser]. Importantly, a period
+     * of zero milliseconds will always be included.
+     */
+    fun parse(value: String): List<Int> {
+        var periods = mutableSetOf(0)
+        if (value.isNotEmpty()) {
+            periods = (value.split(delimiter)
+                .map {
+                    try {
+                        if (isMinuteFormat) {
+                            (it.toFloat() * 1000 * 60).toInt()
+                        } else {
+                            Duration.parse(it.trim()).inWholeMilliseconds.toInt()
+                        }
+                    } catch (_: Exception) {
+                        0 // safely default to 0
+                    }
+                }).toMutableSet()
+        }
+
+        // always notify at the actual reminder time
+        periods.add(0)
+
+        return periods.sortedDescending()
+    }
+}

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -467,6 +467,19 @@
     <string name="pref_key_pre_notify_property" translatable="false">pref_key_pre_notify_property</string>
     <string name="pref_default_pre_notify_property" translatable="false">notify</string>
 
+    <string name="pref_key_pre_notify_format" translatable="false">name</string>
+    <string name="pref_default_pre_notify_format" translatable="false">@string/pref_value_pre_notify_format_minutes</string>
+    <string name="pref_value_pre_notify_format_minutes" translatable="false">minutes</string>
+    <string name="pref_value_pre_notify_format_parse" translatable="false">parse</string>
+    <string-array name="pre_notify_format">
+        <item>@string/pre_notfiy_format_minutes</item>
+        <item>@string/pre_notfiy_format_parse</item>
+    </string-array>
+    <string-array name="pre_notify_format_values">
+        <item>@string/pref_value_pre_notify_format_minutes</item>
+        <item>@string/pref_value_pre_notify_format_parse</item>
+    </string-array>
+
     <string name="pref_key_breadcrumbs_target" translatable="false">pref_key_breadcrumbs_target</string>
     <string name="pref_default_breadcrumbs_target" translatable="false">note_details</string>
 

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -467,19 +467,6 @@
     <string name="pref_key_pre_notify_property" translatable="false">pref_key_pre_notify_property</string>
     <string name="pref_default_pre_notify_property" translatable="false">notify</string>
 
-    <string name="pref_key_pre_notify_format" translatable="false">name</string>
-    <string name="pref_default_pre_notify_format" translatable="false">@string/pref_value_pre_notify_format_minutes</string>
-    <string name="pref_value_pre_notify_format_minutes" translatable="false">minutes</string>
-    <string name="pref_value_pre_notify_format_parse" translatable="false">parse</string>
-    <string-array name="pre_notify_format">
-        <item>@string/pre_notfiy_format_minutes</item>
-        <item>@string/pre_notfiy_format_parse</item>
-    </string-array>
-    <string-array name="pre_notify_format_values">
-        <item>@string/pref_value_pre_notify_format_minutes</item>
-        <item>@string/pref_value_pre_notify_format_parse</item>
-    </string-array>
-
     <string name="pref_key_breadcrumbs_target" translatable="false">pref_key_breadcrumbs_target</string>
     <string name="pref_default_breadcrumbs_target" translatable="false">note_details</string>
 

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -464,6 +464,9 @@
     <string name="pref_key_set_last_repeat_on_time_shift" translatable="false">pref_key_set_last_repeat_on_time_shift</string>
     <bool name="pref_default_set_last_repeat_on_time_shift" translatable="false">true</bool>
 
+    <string name="pref_key_pre_notify_property" translatable="false">pref_key_pre_notify_property</string>
+    <string name="pref_default_pre_notify_property" translatable="false">notify</string>
+
     <string name="pref_key_breadcrumbs_target" translatable="false">pref_key_breadcrumbs_target</string>
     <string name="pref_default_breadcrumbs_target" translatable="false">note_details</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -583,6 +583,8 @@
     <string name="log_on_time_shift_summary">Log time when note with repeater is marked as done</string>
     <string name="set_last_repeat_on_time_shift">Set property on time shift</string>
     <string name="set_last_repeat_on_time_shift_summary">Set time when note with repeater is marked as done</string>
+    <string name="pre_notify_property">Pre-notification Property</string>
+    <string name="pre_notify_property_summary">The property that contains a comma-separated list of pre-notification intervals of a given node.</string>
     <string name="background_opacity">Background opacity</string>
     <string name="update_frequency">Update frequency</string>
     <string name="git">Git</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -585,6 +585,11 @@
     <string name="set_last_repeat_on_time_shift_summary">Set time when note with repeater is marked as done</string>
     <string name="pre_notify_property">Pre-notification Property</string>
     <string name="pre_notify_property_summary">The property that contains a comma-separated list of pre-notification intervals of a given node.</string>
+    <string name="pre_notify_format">Pre-notfication format</string>
+    <string name="pre_notify_format_desc">The format of the pre-notification property syntax.</string>
+    <string name="pre_notfiy_format_minutes">Space separated minute values</string>
+    <string name="pre_notfiy_format_parse">Comma separated time intervals with advanced syntax</string>
+
     <string name="background_opacity">Background opacity</string>
     <string name="update_frequency">Update frequency</string>
     <string name="git">Git</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -585,10 +585,6 @@
     <string name="set_last_repeat_on_time_shift_summary">Set time when note with repeater is marked as done</string>
     <string name="pre_notify_property">Pre-notification Property</string>
     <string name="pre_notify_property_summary">The property that contains a comma-separated list of pre-notification intervals of a given node.</string>
-    <string name="pre_notify_format">Pre-notfication format</string>
-    <string name="pre_notify_format_desc">The format of the pre-notification property syntax.</string>
-    <string name="pre_notfiy_format_minutes">Space separated minute values</string>
-    <string name="pre_notfiy_format_parse">Comma separated time intervals with advanced syntax</string>
 
     <string name="background_opacity">Background opacity</string>
     <string name="update_frequency">Update frequency</string>

--- a/app/src/main/res/xml/prefs_screen_notifications.xml
+++ b/app/src/main/res/xml/prefs_screen_notifications.xml
@@ -35,13 +35,4 @@
         android:defaultValue="@string/pref_default_pre_notify_property"
         app:useSimpleSummaryProvider="true"/>
 
-    <ListPreference
-        android:key="@string/pref_key_pre_notify_format"
-        android:title="@string/pre_notify_format"
-        android:dialogTitle="@string/pre_notify_format_desc"
-        android:entries="@array/pre_notify_format"
-        android:entryValues="@array/pre_notify_format_values"
-        android:defaultValue="@string/pref_default_pre_notify_format"
-        app:useSimpleSummaryProvider="true"/>
-
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/prefs_screen_notifications.xml
+++ b/app/src/main/res/xml/prefs_screen_notifications.xml
@@ -24,4 +24,15 @@
         android:title="@string/show_sync_notifications_title"
         android:summary="@string/show_sync_notifications_summary"
         android:defaultValue="@bool/pref_default_show_sync_notifications"/>
+
+    <EditTextPreference
+        android:key="@string/pref_key_pre_notify_property"
+        android:title="@string/pre_notify_property"
+        android:selectAllOnFocus="true"
+        android:inputType="text"
+        android:singleLine="true"
+        android:dialogMessage="@string/pre_notify_property_summary"
+        android:defaultValue="@string/pref_default_pre_notify_property"
+        app:useSimpleSummaryProvider="true"/>
+
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/prefs_screen_notifications.xml
+++ b/app/src/main/res/xml/prefs_screen_notifications.xml
@@ -35,4 +35,13 @@
         android:defaultValue="@string/pref_default_pre_notify_property"
         app:useSimpleSummaryProvider="true"/>
 
+    <ListPreference
+        android:key="@string/pref_key_pre_notify_format"
+        android:title="@string/pre_notify_format"
+        android:dialogTitle="@string/pre_notify_format_desc"
+        android:entries="@array/pre_notify_format"
+        android:entryValues="@array/pre_notify_format_values"
+        android:defaultValue="@string/pref_default_pre_notify_format"
+        app:useSimpleSummaryProvider="true"/>
+
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml/prefs_screen_reminders.xml
@@ -5,7 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/prefs_title_reminders">
 
-    <SwitchPreference
+   <SwitchPreference
         android:key="@string/pref_key_use_reminders_for_scheduled_times"
         android:title="@string/pref_title_reminders_for_scheduled_times"
         android:summary="@string/pref_title_summary_reminders_for_scheduled_times"

--- a/app/src/main/res/xml/prefs_screen_reminders.xml
+++ b/app/src/main/res/xml/prefs_screen_reminders.xml
@@ -5,7 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/prefs_title_reminders">
 
-   <SwitchPreference
+    <SwitchPreference
         android:key="@string/pref_key_use_reminders_for_scheduled_times"
         android:title="@string/pref_title_reminders_for_scheduled_times"
         android:summary="@string/pref_title_summary_reminders_for_scheduled_times"


### PR DESCRIPTION
This allows to configure "pre-notifications" for reminders through a property (`notify` by default) with a space separated list of durations (https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.time/-duration/-companion/parse.html).

The format for specifying the pre-notification delay is a whitespace separated list of
elements that can be integers (interpreted as minutes) or quoted strings will be parsed
by [kotlin.time.Duration.parse].

An example is `10 "2h" "1 day"` corresponding to three pre-notifications 10 minutes, two hours and one day in advance, respectively.

This functionality is separate from vanilla org on purpose to allow for more flexibility in the pre-notification interval specification. I believe this is relatively easy to integrate with something like `org-wild-notifier`.

Depends on https://github.com/orgzly-revived/org-java/pull/12

Down the road it would be nice to have some UI for this, but for now it works for me :).