### PR TITLE
make `.orgzlyignore` filename configurable

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/repos/DirectoryRepoTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/repos/DirectoryRepoTest.java
@@ -98,7 +98,7 @@ public class DirectoryRepoTest extends OrgzlyTest {
         MiscUtils.writeStringToFile("content", new File(dirFile, "file3.org"));
 
         // Add .orgzlyignore file
-        MiscUtils.writeStringToFile("*1.org\nfile3*", new File(dirFile, RepoIgnoreNode.IGNORE_FILE));
+        MiscUtils.writeStringToFile("*1.org\nfile3*", new File(dirFile, RepoIgnoreNode.ignore_file()));
 
         List<VersionedRook> books = repo.getBooks();
 

--- a/app/src/androidTest/java/com/orgzly/android/repos/RepoIgnoreNodeTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/repos/RepoIgnoreNodeTest.kt
@@ -13,7 +13,7 @@ class RepoIgnoreNodeTest : OrgzlyTest() {
 
     class MockRepoWithMockIgnoreFile : MockRepo(repoWithProps, null) {
         override fun openRepoFileInputStream(repoRelativePath: String): InputStream {
-            if (repoRelativePath == RepoIgnoreNode.IGNORE_FILE) {
+            if (repoRelativePath == RepoIgnoreNode.ignore_file()) {
                 val ignoreFileContents = """
                     IgnoredAnywhere.org
                     /OnlyIgnoredInRoot.org

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -526,6 +526,16 @@ public class AppPreferences {
     }
 
     /*
+     * Orgzlyignore file
+     */
+
+    public static String orgzlyignoreFile(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_orgzlyignore_file),
+                context.getResources().getString(R.string.pref_default_orgzlyignore_file));
+    }
+
+    /*
      * Click action.
      */
 

--- a/app/src/main/java/com/orgzly/android/repos/MockRepo.java
+++ b/app/src/main/java/com/orgzly/android/repos/MockRepo.java
@@ -11,7 +11,6 @@ import com.orgzly.android.prefs.AppPreferences;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -71,7 +70,7 @@ public class MockRepo implements SyncRepo {
 
     @Override
     public InputStream openRepoFileInputStream(String repoRelativePath) throws IOException {
-        if (repoRelativePath.equals(RepoIgnoreNode.IGNORE_FILE) && ignoreRules != null) {
+        if (repoRelativePath.equals(RepoIgnoreNode.ignore_file()) && ignoreRules != null) {
             return new ByteArrayInputStream(ignoreRules.getBytes());
         } else {
             throw new FileNotFoundException();

--- a/app/src/main/java/com/orgzly/android/repos/RepoIgnoreNode.kt
+++ b/app/src/main/java/com/orgzly/android/repos/RepoIgnoreNode.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import com.orgzly.R
 import com.orgzly.android.App
+import com.orgzly.android.prefs.AppPreferences
 import org.eclipse.jgit.ignore.IgnoreNode
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -13,7 +14,7 @@ class RepoIgnoreNode(repo: SyncRepo) : IgnoreNode() {
 
     init {
         try {
-            val inputStream = repo.openRepoFileInputStream(IGNORE_FILE)
+            val inputStream = repo.openRepoFileInputStream(ignore_file())
             inputStream.use {
                 parse(it)
             }
@@ -49,13 +50,14 @@ class RepoIgnoreNode(repo: SyncRepo) : IgnoreNode() {
             throw IOException(
                 App.getAppContext().getString(
                     R.string.error_file_matches_repo_ignore_rule,
-                    IGNORE_FILE,
+                    ignore_file(),
                 )
             )
         }
     }
 
     companion object {
-        const val IGNORE_FILE = ".orgzlyignore"
+        @JvmStatic
+        fun ignore_file(): String = AppPreferences.orgzlyignoreFile(App.getAppContext())
     }
 }

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -619,4 +619,7 @@
     <string name="pref_key_notes_clipboard" translatable="false">pref_key_notes_clipboard</string>
     <string name="pref_key_refile_last_location" translatable="false">pref_key_refile_last_location</string>
 
+    <!-- Repository ignore file. -->
+    <string name="pref_key_orgzlyignore_file" translatable="false">pref_key_orgzlyignore_file</string>
+    <string name="pref_default_orgzlyignore_file" translatable="false">.orgzlyignore</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -734,4 +734,7 @@
     <string name="note_does_not_contain_valid_json">Note does not contain valid JSON.</string>
     <string name="imported_json_is_missing_mandatory_fields">Imported JSON is missing mandatory fields.</string>
     <string name="note_has_no_content">Note has no content.</string>
+
+    <string name="orgzlyignore_file">Ignore pattern filename</string>
+    <string name="orgzlyignore_file_desc">The path of the file containing the ignore patterns relative to the repository root.</string>
 </resources>

--- a/app/src/main/res/xml/prefs_screen_sync.xml
+++ b/app/src/main/res/xml/prefs_screen_sync.xml
@@ -15,6 +15,16 @@
             android:targetClass="com.orgzly.android.ui.repos.ReposActivity"/>
     </Preference>
 
+    <EditTextPreference
+        android:key="@string/pref_key_orgzlyignore_file"
+        android:title="@string/orgzlyignore_file"
+        android:selectAllOnFocus="true"
+        android:inputType="text"
+        android:singleLine="true"
+        android:dialogMessage="@string/orgzlyignore_file_desc"
+        android:defaultValue="@string/pref_default_orgzlyignore_file"
+        app:useSimpleSummaryProvider="true"/>
+
     <SwitchPreference
         android:key="@string/pref_key_enable_repo_subfolders"
         android:title="@string/enable_repo_subfolders_preferences_title"

--- a/shared-test/src/main/java/com/orgzly/android/repos/SyncRepoTest.kt
+++ b/shared-test/src/main/java/com/orgzly/android/repos/SyncRepoTest.kt
@@ -103,7 +103,7 @@ interface SyncRepoTest {
             // Given
             val ignoreFileContent = "*\n"
             writeFileToRepo("...", syncRepo, repoManipulationPoint, "book one.org", "folder")
-            writeFileToRepo(ignoreFileContent, syncRepo, repoManipulationPoint, RepoIgnoreNode.IGNORE_FILE)
+            writeFileToRepo(ignoreFileContent, syncRepo, repoManipulationPoint, RepoIgnoreNode.ignore_file())
             // When
             val books = syncRepo.books
             // Then
@@ -115,7 +115,7 @@ interface SyncRepoTest {
             AppPreferences.subfolderSupport(App.getAppContext(), true)
             val ignoreFileContent = "folder/book one.org\n"
             writeFileToRepo("...", syncRepo, repoManipulationPoint, "book one.org", "folder")
-            writeFileToRepo(ignoreFileContent, syncRepo, repoManipulationPoint, RepoIgnoreNode.IGNORE_FILE)
+            writeFileToRepo(ignoreFileContent, syncRepo, repoManipulationPoint, RepoIgnoreNode.ignore_file())
             // When
             val books = syncRepo.books
             // Then
@@ -129,7 +129,7 @@ interface SyncRepoTest {
             val fileName = "My file.org"
             val ignoreFileContent = "$folderName/**\n!$folderName/$fileName\n"
             writeFileToRepo("...", syncRepo, repoManipulationPoint, fileName, folderName)
-            writeFileToRepo(ignoreFileContent, syncRepo, repoManipulationPoint, RepoIgnoreNode.IGNORE_FILE)
+            writeFileToRepo(ignoreFileContent, syncRepo, repoManipulationPoint, RepoIgnoreNode.ignore_file())
             // When
             val books = syncRepo.books
             // Then


### PR DESCRIPTION
Some webdav servers (such as `nginx`) don't allow access to dotfiles.
This PR adds an option to change the name of the orgzlyignore file.

Ideally I'd add this to the configuration of the individual repositories, but I haven't figured out how yet.