### PR TITLE
Allow folding in search

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -855,6 +855,16 @@ public class AppPreferences {
     }
 
     /*
+     * Folding in search
+     */
+
+    public static boolean isSearchFoldable(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_is_search_foldable),
+                context.getResources().getBoolean(R.bool.pref_default_is_search_foldable));
+    }
+
+    /*
      * Keep screen on menu item
      */
 

--- a/app/src/main/java/com/orgzly/android/ui/notes/NoteItemViewBinder.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NoteItemViewBinder.kt
@@ -314,7 +314,7 @@ class NoteItemViewBinder(private val context: Context, private val inBook: Boole
     private fun updateFoldingButtons(context: Context, note: Note, holder: NoteItemViewHolder): Boolean {
         var isVisible = false
 
-        if (inBook) {
+        if (AppPreferences.isSearchFoldable(context) || inBook) {
             val contentFoldable = note.hasContent() &&
                     AppPreferences.isNotesContentFoldable(context) &&
                     AppPreferences.isNotesContentDisplayedInList(context)
@@ -335,7 +335,7 @@ class NoteItemViewBinder(private val context: Context, private val inBook: Boole
             holder.binding.itemHeadFoldButton.visibility = View.VISIBLE
             holder.binding.itemHeadFoldButtonText.visibility = View.VISIBLE
         } else {
-            if (inBook) { // Leave invisible for padding
+            if (AppPreferences.isSearchFoldable(context) || inBook) { // Leave invisible for padding
                 holder.binding.itemHeadFoldButton.visibility = View.INVISIBLE
                 holder.binding.itemHeadFoldButtonText.visibility = View.INVISIBLE
             } else {
@@ -346,7 +346,7 @@ class NoteItemViewBinder(private val context: Context, private val inBook: Boole
 
         // Add horizontal padding when in search results (no bullet, no folding button)
         val horizontalPadding = context.resources.getDimension(R.dimen.screen_edge).toInt()
-        if (!inBook) {
+        if (!(inBook || AppPreferences.isSearchFoldable(context))) {
             holder.binding.itemHeadContainer.setPadding(
                     horizontalPadding,
                     holder.binding.itemHeadContainer.paddingTop,

--- a/app/src/main/java/com/orgzly/android/ui/util/TitleGenerator.java
+++ b/app/src/main/java/com/orgzly/android/ui/util/TitleGenerator.java
@@ -128,9 +128,15 @@ public class TitleGenerator {
                 if (!AppPreferences.isNotesContentDisplayedInSearch(mContext)) {
                     display = false;
                 }
+
+                if(AppPreferences.isSearchFoldable(mContext) && note.getPosition().isFolded()) {
+                    display = false;
+                } else {
+                }
             }
 
         } else { // Never displaying content in list
+
             display = false;
         }
 

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -69,6 +69,10 @@
     <string name="pref_key_styled_text_with_marks" translatable="false">pref_key_styled_text_with_marks</string>
     <bool name="pref_default_styled_text_with_marks" translatable="false">false</bool>
 
+    <!-- Folding in search -->
+    <string name="pref_key_is_search_foldable" translatable="false">pref_key_is_search_foldable</string>
+    <bool name="pref_default_is_search_foldable" translatable="false">false</bool>
+
     <!-- Notebooks' sort order. -->
     <string name="pref_key_notebooks_sort_order" translatable="false">pref_key_notebooks_sort_order</string>
     <string name="pref_default_notebooks_sort_order" translatable="false">@string/pref_value_notebooks_sort_order_name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -277,8 +277,10 @@
 
     <string name="scheduled_new_notes_for_today">Schedule new notes for today</string>
     <string name="fold_content">Fold content</string>
+    <string name="fold_search">Fold in search</string>
     <string name="allow_folding_of_content">Allow folding of content</string>
     <string name="display_content_in_search">Display content in search</string>
+    <string name="allow_folding_in_search">Allow folding in search</string>
     <string name="display_content_in_search_results">Display content in search results</string>
     <string name="display_content">Display content</string>
     <string name="display_both_title_and_content">Display both title and content</string>

--- a/app/src/main/res/xml/prefs_screen_notebooks.xml
+++ b/app/src/main/res/xml/prefs_screen_notebooks.xml
@@ -83,6 +83,13 @@
             android:defaultValue="@bool/pref_default_is_notes_content_displayed_in_list"/>
 
         <SwitchPreference
+            android:key="@string/pref_key_is_notes_content_foldable"
+            android:dependency="@string/pref_key_is_notes_content_displayed_in_list"
+            android:title="@string/fold_content"
+            android:summary="@string/allow_folding_of_content"
+            android:defaultValue="@bool/pref_default_is_notes_content_foldable"/>
+
+        <SwitchPreference
             android:key="@string/pref_key_is_notes_content_displayed_in_search"
             android:dependency="@string/pref_key_is_notes_content_displayed_in_list"
             android:title="@string/display_content_in_search"
@@ -90,11 +97,11 @@
             android:defaultValue="@bool/pref_default_is_notes_content_displayed_in_search"/>
 
         <SwitchPreference
-            android:key="@string/pref_key_is_notes_content_foldable"
-            android:dependency="@string/pref_key_is_notes_content_displayed_in_list"
-            android:title="@string/fold_content"
-            android:summary="@string/allow_folding_of_content"
-            android:defaultValue="@bool/pref_default_is_notes_content_foldable"/>
+            android:key="@string/pref_key_is_search_foldable"
+            android:dependency="@string/pref_key_is_notes_content_displayed_in_search"
+            android:title="@string/fold_search"
+            android:summary="@string/allow_folding_in_search"
+            android:defaultValue="@bool/pref_default_is_search_foldable"/>
 
         <SwitchPreference
             android:key="@string/pref_key_content_line_count_displayed"


### PR DESCRIPTION
I use a custom search to manage my todos. Folding the items from the search panel (using the same logic for folding in notes) makes the search screen more usable for me. Added an option to turn it on/off, which defaults to off.