### PR TITLE
Fix nix flake development environment

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,6 +54,17 @@ example:
 
 Make sure you [[https://developer.android.com/training/testing/espresso/setup][turn off animations]] for the device you're testing on.
 
+** Nix
+
+If you are using Nix/NixOS, a flake with a =devShell= exists and can be used via [[https://direnv.net/][direnv]].
+
+# TODO remove this when the issue is fixed and flake is bumped past the fix
+Due to [[https://github.com/NixOS/nixpkgs/issues/402297][this nixpkgs issue]], you must run gradle like this:
+
+#+begin_src shell
+  gradle $GRADLE_OPTS app:assembleDebug
+#+end_src
+
 * Contributing
 
 Please feel free to get involved in the project on GitHub by contributing issues, ideas, or features! 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736012469,
-        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
-        "owner": "nixos",
+        "lastModified": 1745841133,
+        "narHash": "sha256-/wL6jtH7PQWZb/equ6ub9Hiw+hPdQDk+VPuCtTCwsVM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
+        "rev": "a0db7f802e0a3edb9b918cf4d449767bd5fefd4c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       };
     };
     cmakeVersion = "3.22.1";
-    buildToolsVersion = "34.0.0";
+    buildToolsVersion = "35.0.0";
     cmdLineToolsVersion = "8.0";
     androidComposition = pkgs.androidenv.composeAndroidPackages {
         cmdLineToolsVersion = cmdLineToolsVersion;


### PR DESCRIPTION
This brings it into a working state again, documents that a nix development env exists aswell as a workaround for an upstream issue.