### PR TITLE
Use latest org-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
 
     versions.android_test_uiautomator = '2.3.0'
 
-    versions.org_java = '1.3.3'
+    versions.org_java = '1.3.5'
 
     versions.loremipsum = '1.0'
 


### PR DESCRIPTION
This is just a formality to get rid of annoying Renovate PRs; there are no real differences between 1.3.3 and 1.3.5. (1.3.4 contained a change which we reverted in 1.3.5.)