### PR TITLE
Revert "Fast Scroll: enables fast scroll by fixing the conflict betwe…

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
@@ -184,14 +184,6 @@ class BookFragment :
         }
 
         binding.swipeContainer.setup()
-    
-        // Fix the conflict between scroll and pull-to-refresh
-        // The problem is that RecylerView is not a direct child of SwipeRefreshLayout. 
-        // See https://stackoverflow.com/questions/55616525/i-cant-scroll-up-because-of-swipe-refresh-layout
-        binding.swipeContainer.setOnChildScrollUpCallback { parent, child ->
-            // Only allow pull-to-refresh if the recyclerView can't no longer scroll. 
-            binding.fragmentBookRecyclerView.canScrollVertically(-1)
-        }
 
         viewModel.flipperDisplayedChild.observe(viewLifecycleOwner, Observer { child ->
             if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, "Observed flipper displayed child: $child")


### PR DESCRIPTION
…en scroll scrubber and the SwipeRefreshLayout, i.e. when we're dragging the scrubber, the pull-to-refresh guesture prevents it from being dragged further"

This reverts commit 80e34951b2fdd5e1bf59687a9104145151da4700.

This is due to issue #658: On certain devices (not on virtual devices), pull-down-to-sync stopped working completely in the notes view (BookFragment).

Resolves #658.