### PR TITLE
Issue #220: Include 'new note' activity in 'recent activities'

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,7 +65,6 @@
             android:name=".android.ui.share.ShareActivity"
             android:exported="true"
             android:windowSoftInputMode="stateUnchanged"
-            android:excludeFromRecents="true"
             android:taskAffinity="">
 
             <intent-filter>


### PR DESCRIPTION
For background, see the discussion in issue #220. Technically, we stop excluding the ShareActivity from the "recent activities" stack. For some reason, the "new note" shortcuts go via the "share activity" to create new notes.