### PR TITLE
Gradle manual upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     def versions = [:]
 
-    versions.android_gradle_plugin = '8.11.1'
+    versions.android_gradle_plugin = '8.9.2'
 
     versions.kotlin = '2.2.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     def versions = [:]
 
-    versions.android_gradle_plugin = '8.9.2'
+    versions.android_gradle_plugin = '8.10.1'
 
     versions.kotlin = '2.2.0'
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "prConcurrentLimit": 1
+  "prConcurrentLimit": 1,
+  "ignoreDeps": ["com.android.tools.build:gradle"]
 }


### PR DESCRIPTION
It is easier to update the Gradle plugin manually, since the latest version often requires the latest version of Android Studio, and the latter application will nag the user about upgrading the plugin, when possible. So Renovate adds nothing of value, here.