### PR TITLE
Improve the "share to Orgzly" experience

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -1196,6 +1196,16 @@ public class AppPreferences {
     }
 
     /*
+     * Where to put incoming shared text in new note
+     */
+
+    public static String sharedTextPlacement(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_shared_text_placement),
+                context.getResources().getString(R.string.pref_default_shared_text_placement));
+    }
+
+    /*
      * Repository properties map
      */
 

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
@@ -636,7 +636,7 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
             /* Open the keyboard for new notes, unless fragment was given
              * some initial values (for example from ShareActivity).
              */
-            if (viewModel.isNew() && !viewModel.hasInitialData()) {
+            if (viewModel.isNew() && !viewModel.hasInitialTitleData()) {
                 binding.title.toEditMode(0)
             }
         })

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteViewModel.kt
@@ -17,7 +17,12 @@ import com.orgzly.android.ui.NotePlace
 import com.orgzly.android.ui.Place
 import com.orgzly.android.ui.SingleLiveEvent
 import com.orgzly.android.ui.main.MainActivity
-import com.orgzly.android.usecase.*
+import com.orgzly.android.usecase.BookScrollToNote
+import com.orgzly.android.usecase.BookSparseTreeForNote
+import com.orgzly.android.usecase.NoteCreate
+import com.orgzly.android.usecase.NoteDelete
+import com.orgzly.android.usecase.NoteUpdate
+import com.orgzly.android.usecase.UseCaseRunner
 import com.orgzly.android.util.MiscUtils
 import com.orgzly.org.OrgProperties
 import com.orgzly.org.datetime.OrgRange
@@ -233,8 +238,8 @@ class NoteViewModel(
         return place != null
     }
 
-    fun hasInitialData(): Boolean {
-        return !TextUtils.isEmpty(initialData.title) || !TextUtils.isEmpty(initialData.content)
+    fun hasInitialTitleData(): Boolean {
+        return !TextUtils.isEmpty(initialData.title)
     }
 
     fun setBook(b: BookView) {

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -116,7 +116,7 @@ public class ShareActivity extends CommonActivity
             if (type.startsWith("text/")) {
 
                 if (intent.hasExtra(Intent.EXTRA_TEXT)) {
-                    data.title = intent.getStringExtra(Intent.EXTRA_TEXT);
+                    data.content = intent.getStringExtra(Intent.EXTRA_TEXT);
 
                 } else if (intent.hasExtra(Intent.EXTRA_STREAM)) {
                     Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
@@ -145,10 +145,9 @@ public class ShareActivity extends CommonActivity
                     }
                 }
 
-                if (data.title != null && data.content == null && intent.hasExtra(Intent.EXTRA_SUBJECT)) {
+                if (data.content != null && data.title == null && intent.hasExtra(Intent.EXTRA_SUBJECT)) {
                     String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
                     if (subject != null && !subject.isEmpty()) {
-                        data.content = data.title;
                         data.title = subject;
                     }
                 }

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -159,7 +159,8 @@ public class ShareActivity extends CommonActivity
                     if (!data.title.contains("\n")) {
                         try {
                             new URI(data.content);
-                            data.content = "[[" + data.content + "][" + data.title + "]]";
+                            data.title = "[[" + data.content + "][" + data.title + "]]";
+                            data.content = null;
                         } catch (URISyntaxException ignored) {}
                     }
                 }

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -155,10 +155,13 @@ public class ShareActivity extends CommonActivity
 
                 // if it's a url with title, let's turn it into org url
                 if (data.content != null && data.title != null) {
-                    try {
-                        new URI(data.content);
-                        data.content = "[[" + data.content + "][" + data.title + "]]";
-                    } catch (URISyntaxException ignored) {}
+                    // A multi-line "subject" will not make a good link
+                    if (!data.title.contains("\n")) {
+                        try {
+                            new URI(data.content);
+                            data.content = "[[" + data.content + "][" + data.title + "]]";
+                        } catch (URISyntaxException ignored) {}
+                    }
                 }
 
                 // TODO: Was used for direct share shortcuts to pass the book name. Used someplace else?

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -22,6 +22,7 @@ import com.orgzly.android.data.DataRepository;
 import com.orgzly.android.db.entity.Book;
 import com.orgzly.android.db.entity.Note;
 import com.orgzly.android.db.entity.SavedSearch;
+import com.orgzly.android.prefs.AppPreferences;
 import com.orgzly.android.query.Query;
 import com.orgzly.android.query.QueryUtils;
 import com.orgzly.android.query.user.DottedQueryParser;
@@ -116,8 +117,11 @@ public class ShareActivity extends CommonActivity
             if (type.startsWith("text/")) {
 
                 if (intent.hasExtra(Intent.EXTRA_TEXT)) {
-                    data.content = intent.getStringExtra(Intent.EXTRA_TEXT);
-
+                    if (AppPreferences.sharedTextPlacement(App.getAppContext()).equals("in_note_heading")) {
+                        data.title = intent.getStringExtra(Intent.EXTRA_TEXT);
+                    } else {
+                        data.content = intent.getStringExtra(Intent.EXTRA_TEXT);
+                    }
                 } else if (intent.hasExtra(Intent.EXTRA_STREAM)) {
                     Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
 

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -146,8 +146,11 @@ public class ShareActivity extends CommonActivity
                 }
 
                 if (data.title != null && data.content == null && intent.hasExtra(Intent.EXTRA_SUBJECT)) {
-                    data.content = data.title;
-                    data.title = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+                    String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+                    if (subject != null && !subject.isEmpty()) {
+                        data.content = data.title;
+                        data.title = subject;
+                    }
                 }
 
                 // if it's a url with title, let's turn it into org url

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -626,4 +626,18 @@
     <!-- Repository ignore file. -->
     <string name="pref_key_orgzlyignore_file" translatable="false">pref_key_orgzlyignore_file</string>
     <string name="pref_default_orgzlyignore_file" translatable="false">.orgzlyignore</string>
+
+    <!-- Share-to-new-note receiver behavior -->
+    <string name="pref_key_shared_text_placement" translatable="false">pref_key_shared_text_placement</string>
+    <string name="pref_default_shared_text_placement" translatable="false">in_note_content</string>
+
+    <string-array name="shared_text_placement_options">
+        <item>@string/in_note_heading</item>
+        <item>@string/in_note_content</item>
+    </string-array>
+
+    <string-array name="shared_text_placement_option_values">
+        <item>in_note_heading</item>
+        <item>in_note_content</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -738,4 +738,8 @@
 
     <string name="orgzlyignore_file">Ignore pattern filename</string>
     <string name="orgzlyignore_file_desc">The path of the file containing the ignore patterns relative to the repository root.</string>
+
+    <string name="placement_of_shared_text">Placement of shared plain text</string>
+    <string name="in_note_heading">In note heading</string>
+    <string name="in_note_content">In note content</string>
 </resources>

--- a/app/src/main/res/xml/prefs_screen_notebooks.xml
+++ b/app/src/main/res/xml/prefs_screen_notebooks.xml
@@ -249,6 +249,14 @@
             android:title="@string/add_id_property"
             android:summary="@string/populate_the_id_property"
             android:defaultValue="@bool/pref_default_is_new_note_prepend"/>
+
+        <ListPreference
+            android:key="@string/pref_key_shared_text_placement"
+            android:title="@string/placement_of_shared_text"
+            android:entries="@array/shared_text_placement_options"
+            android:entryValues="@array/shared_text_placement_option_values"
+            android:defaultValue="@string/pref_default_shared_text_placement"
+            app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/images">


### PR DESCRIPTION
The commit messages should tell the whole story. The biggest change is in cfcb1b5a52b5870f6b3f416cb20b11f4f26f74e9.

This significantly changes the behavior when sharing only a piece of text. (We throw it into the note body, instead of the title.) So I'm wondering whether this should go behind a feature toggle. Another possibility is to add an "opt-out toggle" for those who want to keep the previous behavior. But I honestly feel that this is so much better, and I'm having trouble imagining the user who's mad because their short strip of text can now not be turned into an Orgzly note without adding a title/heading. So I do at least want to change the default behavior and improve the UX for newcomers. And I feel a toggle would clutter the settings screen and probably not be used by anyone.

Thoughts?

Related issues with relevant discussions:
- #138 
- #332 
- #612 
- #711 