### PR TITLE
Adjust target API in Flake to 35

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         platformToolsVersion = "34.0.5";
         buildToolsVersions = ["30.0.3" "33.0.1" buildToolsVersion];
         includeEmulator = true;
-        platformVersions = ["30" "33" "34"];
+        platformVersions = ["30" "33" "35"];
         includeSources = false;
         includeSystemImages = true;
         systemImageTypes = ["google_apis_playstore"];


### PR DESCRIPTION
Fixes f65c9a88ccf20f3ffaa596d4bdc9ce137f873d45 having changed the target framework, but not adjusted the flake environment to have the new target API available.

With this little patch, the build works again.