### PR TITLE
Allow disabling the creation of org links from shared links

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/ShareActivityTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ShareActivityTest.kt
@@ -223,6 +223,26 @@ class ShareActivityTest : OrgzlyTest() {
     }
 
     @Test
+    fun testUrlishTextWithSubjectExtraOrgLinksDisabled() {
+        val sharedText = "https://website.com/"
+        val sharedSubject = "Website Title"
+        AppPreferences.createOrgLinksFromSharedLinks(context, false)
+        startActivityWithIntent(
+            action = Intent.ACTION_SEND,
+            type = "text/plain",
+            extraText = sharedText,
+            extraSubjectText = sharedSubject)
+
+        // Content should contain the URL
+        onView(withId(R.id.content_view)).check(matches(withText(sharedText)))
+        // Title should contain the "subject"
+        onView(withId(R.id.title_view)).check(matches(withText(sharedSubject)))
+        // Neither title nor content should be in "edit mode"
+        onView(withId(R.id.content_edit)).check(matches(not(isDisplayed())))
+        onView(withId(R.id.title_edit)).check(matches(not(isDisplayed())))
+    }
+
+    @Test
     fun testUrlishAndOtherTextWithSubjectExtra() {
         val sharedText = "https://website.com/ is really cool"
         val sharedSubject = "Website Title"

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -1223,6 +1223,18 @@ public class AppPreferences {
         getDefaultSharedPreferences(context).edit().putString(key, value).apply();
     }
 
+    public static Boolean createOrgLinksFromSharedLinks(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_create_org_links_from_shared_links),
+                context.getResources().getBoolean(R.bool.pref_default_create_org_links_from_shared_links));
+    }
+
+    // Added for test purposes
+    public static void createOrgLinksFromSharedLinks(Context context, Boolean value) {
+        String key = context.getResources().getString(R.string.pref_key_create_org_links_from_shared_links);
+        getDefaultSharedPreferences(context).edit().putBoolean(key, value).apply();
+    }
+
     /*
      * Repository properties map
      */

--- a/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/share/ShareActivity.java
@@ -109,9 +109,8 @@ public class ShareActivity extends CommonActivity
                     data.title = subject;
                 }
                 data.content = intent.getStringExtra(Intent.EXTRA_TEXT);
-                // If it's a URL with title, let's turn it into a org link, unless the "subject"
-                // contains line breaks.
-                if (!data.title.contains("\n")) {
+                if (AppPreferences.createOrgLinksFromSharedLinks(this) &&
+                        !data.title.contains("\n")) {
                     try {
                         new URI(data.content);
                         data.title = "[[" + data.content + "][" + data.title + "]]";

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -639,6 +639,8 @@
     <!-- Share-to-new-note receiver behavior -->
     <string name="pref_key_shared_text_placement" translatable="false">pref_key_shared_text_placement</string>
     <string name="pref_default_shared_text_placement" translatable="false">in_note_content</string>
+    <string name="pref_key_create_org_links_from_shared_links" translatable="false">pref_key_create_org_links_from_shared_links</string>
+    <bool name="pref_default_create_org_links_from_shared_links" translatable="false">true</bool>
 
     <string-array name="shared_text_placement_options">
         <item>@string/in_note_heading</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -746,5 +746,6 @@
     <string name="placement_of_shared_text">Placement of shared plain text</string>
     <string name="in_note_heading">In note heading</string>
     <string name="in_note_content">In note content</string>
+    <string name="create_org_links_from_shared_links">Create org links from shared links</string>
     <string name="book_names_cannot_contain">Book names cannot contain \'../\'</string>
 </resources>

--- a/app/src/main/res/xml/prefs_screen_notebooks.xml
+++ b/app/src/main/res/xml/prefs_screen_notebooks.xml
@@ -257,6 +257,11 @@
             android:entryValues="@array/shared_text_placement_option_values"
             android:defaultValue="@string/pref_default_shared_text_placement"
             app:useSimpleSummaryProvider="true"/>
+
+        <SwitchPreference
+            android:key="@string/pref_key_create_org_links_from_shared_links"
+            android:title="@string/create_org_links_from_shared_links"
+            android:defaultValue="@bool/pref_default_create_org_links_from_shared_links" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/images">


### PR DESCRIPTION
Closes #810.

This builds on top of #811.