### PR TITLE
Pull Request: Add Option to Schedule Notes with Time

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -561,6 +561,15 @@ public class AppPreferences {
     }
 
     /*
+     * Schedule time for new note.
+     */
+    public static boolean isNewNoteTimeScheduled(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_is_new_note_time_scheduled),
+                context.getResources().getBoolean(R.bool.pref_default_is_new_note_time_scheduled));
+    }
+
+    /*
      * Prepend new note.
      */
 

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteBuilder.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteBuilder.kt
@@ -131,14 +131,20 @@ class NoteBuilder {
             return if (AppPreferences.isNewNoteScheduled(context)) {
                 val cal = Calendar.getInstance()
 
-                val timestamp = OrgDateTime.Builder()
-                        .setIsActive(true)
-                        .setYear(cal.get(Calendar.YEAR))
-                        .setMonth(cal.get(Calendar.MONTH))
-                        .setDay(cal.get(Calendar.DAY_OF_MONTH))
-                        .build()
+                val timestampBuilder = OrgDateTime.Builder()
+                    .setIsActive(true)
+                    .setYear(cal.get(Calendar.YEAR))
+                    .setMonth(cal.get(Calendar.MONTH))
+                    .setDay(cal.get(Calendar.DAY_OF_MONTH))
 
-                OrgRange(timestamp).toString()
+                if (AppPreferences.isNewNoteTimeScheduled(context)) {
+                    timestampBuilder
+                        .setHasTime(true)
+                        .setHour(cal.get(Calendar.HOUR_OF_DAY))
+                        .setMinute(cal.get(Calendar.MINUTE))
+                }
+
+                OrgRange(timestampBuilder.build()).toString()
 
             } else {
                 null

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -215,6 +215,9 @@
     <string name="pref_key_is_new_note_scheduled" translatable="false">pref_key_is_new_note_scheduled</string>
     <bool name="pref_default_is_new_note_scheduled" translatable="false">false</bool>
 
+    <string name="pref_key_is_new_note_time_scheduled" translatable="false">pref_key_is_new_note_time_scheduled</string>
+    <bool name="pref_default_is_new_note_time_scheduled" translatable="false">false</bool>
+
     <string name="pref_key_is_new_note_prepend" translatable="false">pref_key_is_new_note_prepend</string>
     <bool name="pref_default_is_new_note_prepend" translatable="false">false</bool>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,9 @@
     <string name="reminder_for_event">Event: %s</string>
 
     <string name="scheduled_new_notes_for_today">Schedule new notes for today</string>
+    <string name="schedule_with_time">Schedule with time</string>
+    <string name="schedule_with_current_time">Include current time when scheduling notes</string>
+
     <string name="fold_content">Fold content</string>
     <string name="fold_search">Fold in search</string>
     <string name="allow_folding_of_content">Allow folding of content</string>

--- a/app/src/main/res/xml/prefs_screen_notebooks.xml
+++ b/app/src/main/res/xml/prefs_screen_notebooks.xml
@@ -239,6 +239,13 @@
             android:defaultValue="@bool/pref_default_is_new_note_scheduled"/>
 
         <SwitchPreference
+            android:key="@string/pref_key_is_new_note_time_scheduled"
+            android:title="@string/schedule_with_time"
+            android:summary="@string/schedule_with_current_time"
+            android:defaultValue="@bool/pref_default_is_new_note_time_scheduled"
+            android:dependency="@string/pref_key_is_new_note_scheduled"/>
+
+        <SwitchPreference
             android:key="@string/pref_key_is_new_note_prepend"
             android:title="@string/prepend"
             android:summary="@string/insert_new_note_at_beginning"


### PR DESCRIPTION
### Pull Request: Add Option to Schedule Notes with Time

#### Overview:

This PR introduces a new feature to the app that allows users to schedule notes with a specific time, in addition to just scheduling them for the day. The feature is controlled by a new setting that is only available when the "Schedule new notes for today" option is enabled.

#### Changes:

1. **New Preference for Time Scheduling:**

   * A new `SwitchPreference` was added to the settings screen (`prefs_screen_notebooks.xml`) that allows users to choose whether the scheduled notes will include a specific time (enabled by the `pref_key_is_new_note_time_scheduled` key).
   * This preference is dependent on the existing "Schedule new notes for today" setting, meaning it will only be available if the first option is enabled.

2. **`AppPreferences.java`:**

   * A new static method `isNewNoteTimeScheduled()` was added to read the user preference for scheduling notes with time. This method checks the corresponding shared preference key `pref_key_is_new_note_time_scheduled`.

3. **`NoteBuilder.kt`:**

   * When scheduling a new note, the logic was updated to build the note's timestamp with time if the new time scheduling option is enabled. This includes adding the current time (hour and minute) to the note's `OrgDateTime` object if the user has selected the "Include current time when scheduling notes" option.

4. **New Strings and Resources:**

   * Two new strings were added for the new settings options:

     * `schedule_with_time` – The title for the new setting in the preferences.
     * `schedule_with_current_time` – The summary for the setting, explaining that it includes the current time when scheduling notes.

5. **Default Behavior:**

   * The new time scheduling preference is disabled by default (`false`), meaning that scheduled notes will only be assigned to the current day unless the user explicitly enables the "Include current time when scheduling notes" option.

### Note:

I added the ability to schedule notes with a specific time, primarily for personal use, to help track exactly when a note was created. Previously, only the date could be set when scheduling a note, but I wanted a more precise way to mark the time of creation.

If there’s anything about this contribution that doesn’t align with how contributions are managed, I'm happy to cooperate and make any necessary adjustments.
