### PR TITLE
Fix division by zero crash in cookie update

### DIFF
--- a/app/src/main/java/com/orgzly/android/util/StateChangeParentTitleUpdater.kt
+++ b/app/src/main/java/com/orgzly/android/util/StateChangeParentTitleUpdater.kt
@@ -13,9 +13,8 @@ class StateChangeParentTitleUpdater(
     private val checkedRegex =
         Regex("^\\s*(?:-|\\d+\\.)\\s+\\[X\\]\\s+.*$", RegexOption.MULTILINE)
 
-    private fun countMatches(content: String, regex: Regex): Int {
-        return regex.findAll(content).count()
-    }
+    private fun percentage(done: Int, total: Int): Int =
+        if (total == 0) 0 else ((done.toDouble() / total) * 100).roundToInt()
 
     fun updateTitleForChildStates(title: String, childStates: Collection<String?>): String {
         if (!percentageRegex.containsMatchIn(title) && !fractionRegex.containsMatchIn(title)) {
@@ -24,10 +23,9 @@ class StateChangeParentTitleUpdater(
 
         val doneCount = childStates.count { this.doneKeywords.contains(it) }
         val totalCount = doneCount + childStates.count { todoKeywords.contains(it) }
-        val percentage = ((doneCount.toDouble() / totalCount) * 100).roundToInt()
 
         return title
-            .replace(percentageRegex, "[$percentage%]")
+            .replace(percentageRegex, "[${percentage(doneCount, totalCount)}%]")
             .replace(fractionRegex, "[$doneCount/$totalCount]")
     }
 
@@ -37,13 +35,11 @@ class StateChangeParentTitleUpdater(
             return title
         }
 
-        val undoneCount = countMatches(content, uncheckedRegex)
-        val doneCount = countMatches(content, checkedRegex)
-        val totalCount = undoneCount + doneCount
-        val percentage = ((doneCount.toDouble() / totalCount) * 100).roundToInt()
+        val doneCount = checkedRegex.findAll(content).count()
+        val totalCount = uncheckedRegex.findAll(content).count() + doneCount
 
         return title
-            .replace(percentageRegex, "[$percentage%]")
+            .replace(percentageRegex, "[${percentage(doneCount, totalCount)}%]")
             .replace(fractionRegex, "[$doneCount/$totalCount]")
     }
 }

--- a/app/src/test/java/com/orgzly/android/util/StateChangeParentTitleUpdaterTest.kt
+++ b/app/src/test/java/com/orgzly/android/util/StateChangeParentTitleUpdaterTest.kt
@@ -1,0 +1,15 @@
+package com.orgzly.android.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StateChangeParentTitleUpdaterTest {
+
+    @Test
+    fun divisionByZero_whenChildrenAreNotTodos() {
+        val updater = StateChangeParentTitleUpdater(listOf("TODO"), listOf("DONE"))
+
+        assertEquals("Test [0%]", updater.updateTitleForChildStates("Test [0%]", listOf(null, null)))
+        assertEquals("Test [0/0]", updater.updateTitleForChildStates("Test [/]", listOf(null, null)))
+    }
+}


### PR DESCRIPTION
When a parent note has [%] or [/] cookie but children are not TODOs (state is null), calculating percentage would divide by zero causing NaN crash.

Added percentage() helper that returns 0 when total is 0.

Fixes #841