### PR TITLE
remove res/v31/strings.xml

### DIFF
--- a/app/src/main/res/values-v31/strings.xml
+++ b/app/src/main/res/values-v31/strings.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources></resources>


### PR DESCRIPTION
The Weblate detected the v31 folder as a language code so it created the orgzly_getting_started.org and strings.xml files. I added the v31 to the excludes and removed the language so the Weblate removed the file `orgzly_getting_started.org`. For some reason the strings.xml (which is empty) wasn't removed so here is removed manually.

And while we on topic there is another problem. I added the `prefs_keys-xml` file to be translatable
https://toolate.othing.xyz/projects/orgzly-revived/prefs_keys-xml/

But it looks like this was a mistake and this strings shouldn't be translatable.
So the Weblate created `values-be` with an empty `prefs_keys.xml` alongside with the `values-be-rBY` that contains the `strings.xml`. 
The strings in the Weblate component are shown as read-only but somehow one language actually have some translated strings https://github.com/orgzly-revived/orgzly-android-revived/blob/master/app/src/main/res/values-zh-rCN/prefs_keys.xml

These strings are indeed marked as translatable in the [values/prefs_keys.xml](https://github.com/orgzly-revived/orgzly-android-revived/blob/master/app/src/main/res/values/prefs_keys.xml#L108C1-L110C70)

There is also [values-v31/prefs_keys.xml](https://github.com/orgzly-revived/orgzly-android-revived/blob/master/app/src/main/res/values-v31/prefs_keys.xml#L13) that has some strings not marked as not translatable.

My prosposition is to use `@string/SOME_KEY` and remove the `prefs_keys.xml` from translation and remove the empty files.
Please let me know it you'll fine with the change, but ideally please make it yourself.