### PR TITLE
Support per-app language config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,6 +97,10 @@ android {
         }
     }
 
+    androidResources {
+        generateLocaleConfig true
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US


### PR DESCRIPTION
[Per app language configuration](https://developer.android.com/guide/topics/resources/app-languages) (accessed through the system app setting page) was introduced in Android 13 (API 33). This pull request enables the feature and specifies the default locale. This means the current in-app preference "Use English language" can be removed for devices above this API, though I have not done that so far.