### PR TITLE
Fix all-day events appearing one day early in Android calendar sync

### DIFF
--- a/app/src/main/java/com/orgzly/android/calendar/CalendarManager.kt
+++ b/app/src/main/java/com/orgzly/android/calendar/CalendarManager.kt
@@ -325,11 +325,12 @@ class CalendarManager(
     private fun adjustEventTimesForTimezone(eventStartTime: Long, eventEndTime: Long, isAllDay: Boolean): Triple<Long, Long, String> {
         return if (isAllDay) {
             val localTimeZone = TimeZone.getDefault()
-            
-            // Convert local timestamp to UTC for all-day events
-            val startTimeInUtc = eventStartTime - localTimeZone.getOffset(eventStartTime)
-            val endTimeInUtc = eventEndTime - localTimeZone.getOffset(eventEndTime)
-            
+
+            // Org all-day timestamps are UTC; Android expects local midnight in UTC.
+            // Add the local offset so the event appears on the correct day.
+            val startTimeInUtc = eventStartTime + localTimeZone.getOffset(eventStartTime)
+            val endTimeInUtc = eventEndTime + localTimeZone.getOffset(eventEndTime)
+
             Triple(startTimeInUtc, endTimeInUtc, "UTC")
         } else {
             Triple(eventStartTime, eventEndTime, TimeZone.getDefault().id)


### PR DESCRIPTION
- Org all-day timestamps are stored as midnight UTC
- Android expects all-day events to use local midnight converted to UTC
- Adjusted timestamps by adding the local timezone offset for correct display
- Preserves proper behavior across DST and different timezones