### PR TITLE
Correct all-day event UTC offset to prevent date shift

### DIFF
--- a/app/src/main/java/com/orgzly/android/calendar/CalendarManager.kt
+++ b/app/src/main/java/com/orgzly/android/calendar/CalendarManager.kt
@@ -326,9 +326,9 @@ class CalendarManager(
         return if (isAllDay) {
             val localTimeZone = TimeZone.getDefault()
             
-            // Convert local timestamp to UTC for all-day events
-            val startTimeInUtc = eventStartTime - localTimeZone.getOffset(eventStartTime)
-            val endTimeInUtc = eventEndTime - localTimeZone.getOffset(eventEndTime)
+            // Convert local timestamp to UTC for all-day events (Add the offset instead of substracting it)
+            val startTimeInUtc = eventStartTime + localTimeZone.getOffset(eventStartTime)
+            val endTimeInUtc = eventEndTime + localTimeZone.getOffset(eventEndTime)
             
             Triple(startTimeInUtc, endTimeInUtc, "UTC")
         } else {


### PR DESCRIPTION
UTC offset was being subtracted instead of being added to all day events in calendar. This made the events appear one day earlier. This should fix the date shift, but please, feel free to tell me if you notice any cases I might have missed.