### PR TITLE
Highlight popup parent item

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/Selection.kt
+++ b/app/src/main/java/com/orgzly/android/ui/Selection.kt
@@ -2,10 +2,6 @@ package com.orgzly.android.ui
 
 import android.os.Bundle
 import android.view.View
-import androidx.annotation.ColorInt
-import com.orgzly.R
-import com.orgzly.android.ui.util.styledAttributes
-import java.util.LinkedHashSet
 
 class Selection {
     // Preserve insertion order so multi-selection actions can respect the order of user clicks.
@@ -98,22 +94,8 @@ class Selection {
         }
     }
 
-    @ColorInt
-    private var selectionBgColor = 0
-
-    fun setBackgroundIfSelected(view: View, id: Long) {
-        if (contains(id)) {
-            if (selectionBgColor == 0) {
-                selectionBgColor = view.context.styledAttributes(intArrayOf(R.attr.colorSecondaryContainer)) { typedArray ->
-                    typedArray.getColor(0, 0)
-                }
-            }
-
-            view.setBackgroundColor(selectionBgColor)
-
-        } else {
-            view.setBackgroundResource(0)
-        }
+    fun setActivatedIfSelected(view: View, id: Long) {
+        view.isActivated = contains(id)
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/books/BooksAdapter.kt
+++ b/app/src/main/java/com/orgzly/android/ui/books/BooksAdapter.kt
@@ -184,7 +184,7 @@ class BooksAdapter(
             /* If it's a dummy book - change opacity. */
             itemView.alpha = if (item.book.isDummy) 0.4f else 1f
 
-            getSelection().setBackgroundIfSelected(binding.itemBookContainer, item.book.id)
+            getSelection().setActivatedIfSelected(binding.itemBookContainer, item.book.id)
         }
     }
 

--- a/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
@@ -53,17 +53,19 @@ abstract class NotesFragment : CommonFragment(), TimestampDialogFragment.OnDateT
 
         notePopup = NotePopup.showWindow(noteId, anchor, location, direction, e1, e2) { _, buttonId ->
             listener.onPopupButtonClick(noteId, buttonId)
-        }
+        }?.also {
+            // On popup shown
 
-        // Enable back handler if popup is shown
-        if (notePopup != null) {
+            // Enable back handler
             notePopupDismissOnBackPress.isEnabled = true
-        }
 
-        // Disable back handler on dismiss
-        notePopup?.setOnDismissListener {
-            notePopup = null
-            notePopupDismissOnBackPress.isEnabled = false
+            // On popup dismiss
+            it.setOnDismissListener {
+                // Disable back handler
+                notePopupDismissOnBackPress.isEnabled = false
+
+                notePopup = null
+            }
         }
 
         return notePopup

--- a/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.PopupWindow
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.content.res.AppCompatResources
 import com.orgzly.BuildConfig
 import com.orgzly.R
 import com.orgzly.android.App
@@ -56,6 +57,11 @@ abstract class NotesFragment : CommonFragment(), TimestampDialogFragment.OnDateT
         }?.also {
             // On popup shown
 
+            // Add highlight to popup parent
+            val oldItemViewBackground = itemView.background
+            itemView.background =
+                AppCompatResources.getDrawable(requireContext(), R.drawable.item_head_background_highlighted)
+
             // Enable back handler
             notePopupDismissOnBackPress.isEnabled = true
 
@@ -63,6 +69,9 @@ abstract class NotesFragment : CommonFragment(), TimestampDialogFragment.OnDateT
             it.setOnDismissListener {
                 // Disable back handler
                 notePopupDismissOnBackPress.isEnabled = false
+
+                // Remove highlight from popup parent
+                itemView.background = oldItemViewBackground
 
                 notePopup = null
             }

--- a/app/src/main/java/com/orgzly/android/ui/notes/book/BookAdapter.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/book/BookAdapter.kt
@@ -112,7 +112,7 @@ class BookAdapter(
 
                 noteItemViewBinder.bind(holder, noteView)
 
-                getSelection().setBackgroundIfSelected(holder.itemView, note.id)
+                getSelection().setActivatedIfSelected(holder.itemView, note.id)
             }
         }
     }

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaAdapter.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaAdapter.kt
@@ -81,7 +81,7 @@ class AgendaAdapter(
 
                 noteViewBinder.bind(holder, item.note, item.timeType)
 
-                getSelection().setBackgroundIfSelected(holder.itemView, item.id)
+                getSelection().setActivatedIfSelected(holder.itemView, item.id)
             }
         }
     }

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/search/SearchAdapter.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/search/SearchAdapter.kt
@@ -50,7 +50,7 @@ class SearchAdapter(
 
         noteItemViewBinder.bind(holder, noteView)
 
-        getSelection().setBackgroundIfSelected(holder.itemView, note.id)
+        getSelection().setActivatedIfSelected(holder.itemView, note.id)
     }
 
     override fun getItemId(position: Int): Long {

--- a/app/src/main/java/com/orgzly/android/ui/savedsearches/SavedSearchesAdapter.kt
+++ b/app/src/main/java/com/orgzly/android/ui/savedsearches/SavedSearchesAdapter.kt
@@ -64,7 +64,7 @@ class SavedSearchesAdapter(
             name.text = savedSearch.name
             query.text = savedSearch.query
 
-            getSelection().setBackgroundIfSelected(container, savedSearch.id)
+            getSelection().setActivatedIfSelected(container, savedSearch.id)
         }
     }
 

--- a/app/src/main/res/color/item_head_background.xml
+++ b/app/src/main/res/color/item_head_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:state_activated="true"
+        android:color="?colorSecondaryContainer" />
+    <item
+        android:color="@android:color/transparent" />
+</selector>

--- a/app/src/main/res/drawable/item_head_background_highlighted.xml
+++ b/app/src/main/res/drawable/item_head_background_highlighted.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke
+        android:width="@dimen/item_head_highlight_width"
+        android:color="?colorSecondary" />
+    <solid
+        android:color="@color/item_head_background" />
+</shape>

--- a/app/src/main/res/layout/item_head.xml
+++ b/app/src/main/res/layout/item_head.xml
@@ -4,6 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/item_head_background"
     android:id="@+id/item_head_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,6 +9,8 @@
     <dimen name="item_head_below_title_padding_cozy">1dp</dimen>
     <dimen name="item_head_below_title_padding_compact">0dp</dimen>
 
+    <dimen name="item_head_highlight_width">2dp</dimen>
+
     <dimen name="dropdown_item_height">48dp</dimen>
     <dimen name="dropdown_item_min_width">96dp</dimen>
 


### PR DESCRIPTION
Visually highlight parent item while popup window is shown. Allows user to easily tell which item a popup window is for.

Rationale: I sometimes have issues telling if the popup window is for the right item, especially for one-line items on compact density.

<img width="672" height="1496" alt="image" src="https://github.com/user-attachments/assets/30fbd46a-c207-4f2b-b413-8738b148d296" />

Also works as expected when item is selected.

<img width="672" height="1496" alt="image" src="https://github.com/user-attachments/assets/a6f1d03d-09be-4ab4-8183-e1881d485727" />

This is just a first draft of the idea. Any feedback on improving it is welcome.