### PR TITLE
Fix flaky instrumented tests and improve CI reliability

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,9 @@ jobs:
 
   instrumentedTests:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         # TODO: Run on lowest and highest supported API
         api-level: [29, 35]

--- a/app/src/androidTest/java/com/orgzly/android/espresso/ActionModeTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ActionModeTest.java
@@ -7,10 +7,12 @@ import androidx.test.core.app.ActivityScenario;
 
 import com.orgzly.R;
 import com.orgzly.android.OrgzlyTest;
+import com.orgzly.android.RetryTestRule;
 import com.orgzly.android.ui.main.MainActivity;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -31,6 +33,9 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.not;
 
 public class ActionModeTest extends OrgzlyTest {
+    @Rule
+    public RetryTestRule mRetryTestRule = new RetryTestRule();
+
     private ActivityScenario<MainActivity> scenario;
 
     @Before

--- a/app/src/androidTest/java/com/orgzly/android/espresso/ActionModeTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ActionModeTest.java
@@ -21,10 +21,12 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.DrawerActions.open;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.orgzly.android.espresso.util.EspressoUtils.onNoteInBook;
 import static com.orgzly.android.espresso.util.EspressoUtils.onNoteInSearch;
+import static com.orgzly.android.espresso.util.EspressoUtils.waitId;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.not;
 
@@ -65,6 +67,7 @@ public class ActionModeTest extends OrgzlyTest {
         scenario = ActivityScenario.launch(MainActivity.class);
 
         onView(allOf(withText("book-one"), isDisplayed())).perform(click());
+        onView(isRoot()).perform(waitId(R.id.fragment_book_recycler_view, 5000));
     }
 
     @After

--- a/app/src/androidTest/java/com/orgzly/android/espresso/AgendaFragmentTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/AgendaFragmentTest.java
@@ -7,6 +7,7 @@ import static androidx.test.espresso.action.ViewActions.swipeLeft;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
@@ -15,6 +16,7 @@ import static com.orgzly.android.espresso.util.EspressoUtils.onItemInAgenda;
 import static com.orgzly.android.espresso.util.EspressoUtils.onNotesInAgenda;
 import static com.orgzly.android.espresso.util.EspressoUtils.recyclerViewItemCount;
 import static com.orgzly.android.espresso.util.EspressoUtils.searchForTextCloseKeyboard;
+import static com.orgzly.android.espresso.util.EspressoUtils.waitForExactAdapterCount;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
@@ -74,6 +76,17 @@ public class AgendaFragmentTest extends OrgzlyTest {
         scenario.close();
     }
 
+    /** Wait for agenda adapter to reach expected count, then assert. */
+    private void checkAgendaItemCount(int count) {
+        onNotesInAgenda().perform(waitForExactAdapterCount(count, 5000));
+        onNotesInAgenda().check(matches(recyclerViewItemCount(count)));
+    }
+
+    /** Wait for action mode to appear after longClick. */
+    private void waitForActionMode(int actionButtonId) {
+        onView(isRoot()).perform(EspressoUtils.waitId(actionButtonId, 5000));
+    }
+
     @Test
     public void testAgendaSavedSearch() {
         testUtils.setupBook("book-three",
@@ -92,16 +105,19 @@ public class AgendaFragmentTest extends OrgzlyTest {
          * 7 Note C
          * 7 Note 2
          */
-        onView(withId(R.id.fragment_query_agenda_recycler_view)).check(matches(recyclerViewItemCount(24)));
+        onView(withId(R.id.fragment_query_agenda_recycler_view))
+                .perform(waitForExactAdapterCount(24, 5000));
+        onView(withId(R.id.fragment_query_agenda_recycler_view))
+                .check(matches(recyclerViewItemCount(24)));
     }
 
     @Test
     public void testWithNoBook() {
         scenario = ActivityScenario.launch(MainActivity.class);
         searchForTextCloseKeyboard(".it.done (s.7d or d.7d) ad.7");
-        onNotesInAgenda().check(matches(recyclerViewItemCount(7)));
+        checkAgendaItemCount(7);
         searchForTextCloseKeyboard(".it.done (s.7d or d.7d) ad.3");
-        onNotesInAgenda().check(matches(recyclerViewItemCount(3)));
+        checkAgendaItemCount(3);
     }
 
     @Test
@@ -114,7 +130,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
         scenario = defaultSetUp();
         searchForTextCloseKeyboard(".it.done (s.7d or d.7d) ad.1");
 
-        onNotesInAgenda().check(matches(recyclerViewItemCount(6)));
+        checkAgendaItemCount(6);
         onItemInAgenda(0, R.id.item_agenda_divider_text).check(matches(allOf(withText(R.string.overdue), isDisplayed())));
         onItemInAgenda(1, R.id.item_head_title_view).check(matches(allOf(withText(endsWith("Note 5")), isDisplayed())));
         // Day 1
@@ -129,7 +145,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
         AppPreferences.groupScheduledWithTodayInAgenda(context, false);
         searchForTextCloseKeyboard(".it.done (s.7d or d.7d) ad.1");
 
-        onNotesInAgenda().check(matches(recyclerViewItemCount(7)));
+        checkAgendaItemCount(7);
         onItemInAgenda(0, R.id.item_agenda_divider_text).check(matches(allOf(withText(R.string.overdue), isDisplayed())));
         onItemInAgenda(1, R.id.item_head_title_view).check(matches(allOf(withText(endsWith("Note B")), isDisplayed())));
         onItemInAgenda(2, R.id.item_head_title_view).check(matches(allOf(withText(endsWith("Note C")), isDisplayed())));
@@ -140,7 +156,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
     }
 
     @Test
-    public void testOverdueScheduledNotRepeating() {
+    public void testAgendaRepeatingNote() {
         testUtils.setupBook("book-three",
                 "Sample book used for tests\n" +
 
@@ -149,7 +165,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
         scenario = ActivityScenario.launch(MainActivity.class);
         searchForTextCloseKeyboard("ad.1");
 
-        onNotesInAgenda().check(matches(recyclerViewItemCount(2)));
+        checkAgendaItemCount(2);
         onItemInAgenda(1, R.id.item_head_title_view).check(matches(allOf(withText(endsWith("Repeating note 1")), isDisplayed())));
     }
 
@@ -163,7 +179,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
 
         scenario = ActivityScenario.launch(MainActivity.class);
         searchForTextCloseKeyboard("ad.5");
-        onNotesInAgenda().check(matches(recyclerViewItemCount(10)));
+        checkAgendaItemCount(10);
     }
 
     @Test
@@ -181,8 +197,9 @@ public class AgendaFragmentTest extends OrgzlyTest {
          * 6 Note 2
          */
         onItemInAgenda(3).perform(longClick());
+        waitForActionMode(R.id.toggle_state);
         onView(withId(R.id.toggle_state)).perform(click());
-        onNotesInAgenda().check(matches(recyclerViewItemCount(21)));
+        checkAgendaItemCount(21);
     }
 
     @Test
@@ -200,8 +217,9 @@ public class AgendaFragmentTest extends OrgzlyTest {
          * 6 Note 2
          */
         onItemInAgenda(2).perform(longClick());
+        waitForActionMode(R.id.toggle_state);
         onView(withId(R.id.toggle_state)).perform(click());
-        onNotesInAgenda().check(matches(recyclerViewItemCount(15)));
+        checkAgendaItemCount(15);
     }
 
     @Test
@@ -219,8 +237,9 @@ public class AgendaFragmentTest extends OrgzlyTest {
          * 6 Note 2
          */
         onItemInAgenda(2).perform(longClick());
+        waitForActionMode(R.id.toggle_state);
         onView(withId(R.id.toggle_state)).perform(click());
-        onNotesInAgenda().check(matches(recyclerViewItemCount(15)));
+        checkAgendaItemCount(15);
     }
 
     @Test
@@ -240,6 +259,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
          * 6 Note 2
          */
         onItemInAgenda(1).perform(longClick());
+        waitForActionMode(R.id.schedule);
         onView(withId(R.id.schedule)).perform(click());
         onView(withId(R.id.date_picker_button)).perform(click());
         onView(withClassName(equalTo(DatePicker.class.getName())))
@@ -248,9 +268,8 @@ public class AgendaFragmentTest extends OrgzlyTest {
                         tomorrow.getMonthOfYear(),
                         tomorrow.getDayOfMonth()));
         onView(withText(android.R.string.ok)).perform(click());
-        SystemClock.sleep(500);
         onView(withText(R.string.set)).perform(click());
-        onNotesInAgenda().check(matches(recyclerViewItemCount(21)));
+        checkAgendaItemCount(21);
     }
 
     @Test
@@ -258,13 +277,13 @@ public class AgendaFragmentTest extends OrgzlyTest {
         scenario = defaultSetUp();
 
         searchForTextCloseKeyboard(".it.done ad.7");
-        onNotesInAgenda().check(matches(recyclerViewItemCount(22)));
+        checkAgendaItemCount(22);
 
         SystemClock.sleep(500);
         scenario.onActivity(activity ->
                 activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE));
 
-        onNotesInAgenda().check(matches(recyclerViewItemCount(22)));
+        checkAgendaItemCount(22);
     }
 
     @Test
@@ -278,9 +297,10 @@ public class AgendaFragmentTest extends OrgzlyTest {
 
         searchForTextCloseKeyboard("i.todo ad.3");
 
-        onNotesInAgenda().check(matches(recyclerViewItemCount(9)));
+        checkAgendaItemCount(9);
 
         onItemInAgenda(1).perform(longClick());
+        waitForActionMode(R.id.state);
 
         // Check title for number of selected notes
         onView(allOf(instanceOf(TextView.class), withParent(withId(R.id.top_toolbar))))
@@ -290,7 +310,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
         onView(withId(R.id.state)).perform(click());
         onView(withText(R.string.clear)).perform(click());
 
-        onNotesInAgenda().check(matches(recyclerViewItemCount(6)));
+        checkAgendaItemCount(6);
 
         // Check subtitle for search query
         onView(allOf(instanceOf(TextView.class), not(withText(R.string.agenda)), withParent(withId(R.id.top_toolbar))))
@@ -306,6 +326,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
         searchForTextCloseKeyboard("ad.3");
 
         onItemInAgenda(1).perform(longClick());
+        waitForActionMode(R.id.state);
         onView(withId(R.id.state)).perform(click());
 
         onView(withText("TODO")).check(matches(isChecked()));
@@ -330,7 +351,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
 
         onItemInAgenda(1).perform(click());
 
-        SystemClock.sleep(500);
+        onView(isRoot()).perform(EspressoUtils.waitId(R.id.scroll_view, 5000));
         onView(withId(R.id.scroll_view)).check(matches(isDisplayed()));
         onView(withId(R.id.title_view)).check(matches(withText("Note A")));
     }
@@ -344,6 +365,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
 
         searchForTextCloseKeyboard(".it.done ad.7");
         onItemInAgenda(1).perform(longClick());
+        waitForActionMode(R.id.state);
         onView(withId(R.id.state)).perform(click());
         onView(withText("NEXT")).perform(click());
     }
@@ -355,7 +377,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
         searchForTextCloseKeyboard("ad.1");
 
         // Overdue, note (deadline), today
-        onNotesInAgenda().check(matches(recyclerViewItemCount(3)));
+        checkAgendaItemCount(3);
     }
 
     @Test
@@ -364,8 +386,7 @@ public class AgendaFragmentTest extends OrgzlyTest {
         scenario = ActivityScenario.launch(MainActivity.class);
         searchForTextCloseKeyboard("ad.1");
         // today, note (scheduled)
-        SystemClock.sleep(500);
-        onNotesInAgenda().check(matches(recyclerViewItemCount(2)));
+        checkAgendaItemCount(2);
     }
 
     @Test
@@ -374,6 +395,6 @@ public class AgendaFragmentTest extends OrgzlyTest {
         scenario = ActivityScenario.launch(MainActivity.class);
         searchForTextCloseKeyboard("ad.1");
         // Today
-        onNotesInAgenda().check(matches(recyclerViewItemCount(1)));
+        checkAgendaItemCount(1);
     }
 }

--- a/app/src/androidTest/java/com/orgzly/android/espresso/AgendaSortingTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/AgendaSortingTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import com.orgzly.R
 import com.orgzly.android.OrgzlyTest
+import com.orgzly.android.RetryTestRule
 import com.orgzly.android.espresso.util.EspressoUtils.onItemInAgenda
 import com.orgzly.android.espresso.util.EspressoUtils.onNotesInAgenda
 import com.orgzly.android.espresso.util.EspressoUtils.recyclerViewItemCount
@@ -24,9 +25,13 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.endsWith
 import org.joda.time.DateTime
 import org.junit.After
+import org.junit.Rule
 import org.junit.Test
 
 class AgendaSortingTest : OrgzlyTest() {
+    @get:Rule
+    val retryTestRule = RetryTestRule()
+
     private lateinit var scenario: ActivityScenario<MainActivity>
 
     private fun getToday(): String {

--- a/app/src/androidTest/java/com/orgzly/android/espresso/BookChooserActivityTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/BookChooserActivityTest.java
@@ -6,10 +6,12 @@ import android.content.Intent;
 import androidx.test.core.app.ActivityScenario;
 
 import com.orgzly.android.OrgzlyTest;
+import com.orgzly.android.RetryTestRule;
 import com.orgzly.android.ui.BookChooserActivity;
 
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static android.app.Activity.RESULT_OK;
@@ -25,6 +27,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
 public class BookChooserActivityTest extends OrgzlyTest {
+    @Rule
+    public RetryTestRule mRetryTestRule = new RetryTestRule();
+
     private ActivityScenario<BookChooserActivity> startActivityWithCreateShortcutAction() {
         Intent intent = new Intent(context, BookChooserActivity.class);
         intent.setAction(Intent.ACTION_CREATE_SHORTCUT);

--- a/app/src/androidTest/java/com/orgzly/android/espresso/BookPrefaceTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/BookPrefaceTest.kt
@@ -11,10 +11,15 @@ import com.orgzly.android.OrgzlyTest
 import com.orgzly.android.espresso.util.EspressoUtils.*
 import com.orgzly.android.ui.main.MainActivity
 import org.hamcrest.Matchers.not
+import com.orgzly.android.RetryTestRule
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class BookPrefaceTest : OrgzlyTest() {
+    @get:Rule
+    val retryTestRule = RetryTestRule()
+
     @Before
     @Throws(Exception::class)
     override fun setUp() {

--- a/app/src/androidTest/java/com/orgzly/android/espresso/BooksSortOrderTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/BooksSortOrderTest.kt
@@ -13,11 +13,16 @@ import com.orgzly.android.OrgzlyTest
 import com.orgzly.android.espresso.util.EspressoUtils.*
 import com.orgzly.android.ui.main.MainActivity
 import org.hamcrest.Matchers.hasToString
+import com.orgzly.android.RetryTestRule
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 
 class BooksSortOrderTest : OrgzlyTest() {
+    @get:Rule
+    val retryTestRule = RetryTestRule()
+
     @Before
     @Throws(Exception::class)
     override fun setUp() {

--- a/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
@@ -10,6 +10,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.orgzly.R
 import com.orgzly.android.App
 import com.orgzly.android.OrgzlyTest
+import com.orgzly.android.RetryTestRule
 import com.orgzly.android.espresso.util.EspressoUtils.clickClickableSpan
 import com.orgzly.android.espresso.util.EspressoUtils.onBook
 import com.orgzly.android.espresso.util.EspressoUtils.onNoteInBook
@@ -29,6 +30,9 @@ import org.junit.runners.Parameterized
 class ExternalLinksTest(private val param: Parameter) : OrgzlyTest() {
 
     data class Parameter(val link: String, val check: () -> Any)
+
+    @get:Rule
+    val retryTestRule = RetryTestRule()
 
     @get:Rule
     val grantPermissionRule: GrantPermissionRule = if (Build.VERSION.SDK_INT >= 33) {

--- a/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ExternalLinksTest.kt
@@ -2,7 +2,6 @@ package com.orgzly.android.espresso
 
 import android.os.Build
 import android.os.Environment
-import android.os.SystemClock
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -15,6 +14,9 @@ import com.orgzly.android.espresso.util.EspressoUtils.clickClickableSpan
 import com.orgzly.android.espresso.util.EspressoUtils.onBook
 import com.orgzly.android.espresso.util.EspressoUtils.onNoteInBook
 import com.orgzly.android.espresso.util.EspressoUtils.onSnackbar
+import com.orgzly.android.espresso.util.EspressoUtils.waitId
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.orgzly.android.ui.main.MainActivity
 import org.hamcrest.Matchers.startsWith
 import org.junit.Rule
@@ -74,7 +76,7 @@ class ExternalLinksTest(private val param: Parameter) : OrgzlyTest() {
             // Click on link
             onNoteInBook(1, R.id.item_head_content_view).perform(clickClickableSpan(param.link))
 
-            SystemClock.sleep(500)
+            onView(isRoot()).perform(waitId(com.google.android.material.R.id.snackbar_text, 5000))
 
             param.check()
         }

--- a/app/src/androidTest/java/com/orgzly/android/espresso/GitRepoTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/GitRepoTest.kt
@@ -1,6 +1,5 @@
 package com.orgzly.android.espresso
 
-import android.os.SystemClock
 import androidx.core.net.toUri
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
@@ -72,7 +71,6 @@ class GitRepoTest : OrgzlyTest() {
         assertEquals(3, dataRepository.getBooks().size)
         ActivityScenario.launch(MainActivity::class.java).use {
             sync()
-            SystemClock.sleep(500)
             onBook(0, R.id.item_book_link_repo).check(ViewAssertions.matches(withText(repo.url)))
             onBook(1, R.id.item_book_link_repo).check(ViewAssertions.matches(withText(repo.url)))
             onBook(2, R.id.item_book_link_repo).check(ViewAssertions.matches(withText(repo.url)))

--- a/app/src/androidTest/java/com/orgzly/android/espresso/InternalLinksTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/InternalLinksTest.kt
@@ -8,16 +8,21 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import com.orgzly.R
 import com.orgzly.android.OrgzlyTest
+import com.orgzly.android.RetryTestRule
 import com.orgzly.android.espresso.util.EspressoUtils.*
 import com.orgzly.android.ui.main.MainActivity
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.instanceOf
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 
 class InternalLinksTest : OrgzlyTest() {
+    @get:Rule
+    val retryTestRule = RetryTestRule()
+
     private lateinit var scenario: ActivityScenario<MainActivity>
 
     @Before
@@ -82,6 +87,7 @@ class InternalLinksTest : OrgzlyTest() {
         scenario = ActivityScenario.launch(MainActivity::class.java)
 
         onBook(0).perform(click())
+        onView(isRoot()).perform(waitId(R.id.fragment_book_recycler_view, 5000))
     }
 
     @After

--- a/app/src/androidTest/java/com/orgzly/android/espresso/InternalLinksTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/InternalLinksTest.kt
@@ -1,6 +1,5 @@
 package com.orgzly.android.espresso
 
-import android.os.SystemClock
 import android.widget.TextView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
@@ -95,7 +94,7 @@ class InternalLinksTest : OrgzlyTest() {
     fun testDifferentCaseUuidInternalLink() {
         onNoteInBook(1, R.id.item_head_content_view)
                 .perform(clickClickableSpan("id:bdce923b-C3CD-41ED-B58E-8BDF8BABA54F"))
-        SystemClock.sleep(500)
+        onView(isRoot()).perform(waitId(R.id.title_view, 5000))
         onView(withId(R.id.title_view)).check(matches(withText("Note [b-2]")))
     }
 
@@ -103,7 +102,7 @@ class InternalLinksTest : OrgzlyTest() {
     fun testDifferentCaseCustomIdInternalLink() {
         onNoteInBook(2, R.id.item_head_content_view)
                 .perform(clickClickableSpan("#Different case custom id"))
-        SystemClock.sleep(500)
+        onView(isRoot()).perform(waitId(R.id.title_view, 5000))
         onView(withId(R.id.title_view)).check(matches(withText("Note [b-1]")))
     }
 
@@ -111,7 +110,7 @@ class InternalLinksTest : OrgzlyTest() {
     fun testCustomIdLink() {
         onNoteInBook(3, R.id.item_head_content_view)
                 .perform(clickClickableSpan("#Link to note in a different book"))
-        SystemClock.sleep(500)
+        onView(isRoot()).perform(waitId(R.id.title_view, 5000))
         onView(withId(R.id.title_view)).check(matches(withText("Note [b-3]")))
     }
 
@@ -119,6 +118,7 @@ class InternalLinksTest : OrgzlyTest() {
     fun testBookLink() {
         onNoteInBook(4, R.id.item_head_content_view)
                 .perform(clickClickableSpan("file:book-b.org"))
+        onView(isRoot()).perform(waitId(R.id.fragment_book_view_flipper, 5000))
         onView(withId(R.id.fragment_book_view_flipper)).check(matches(isDisplayed()))
         onNoteInBook(1, R.id.item_head_title_view).check(matches(withText("Note [b-1]")))
     }
@@ -127,6 +127,7 @@ class InternalLinksTest : OrgzlyTest() {
     fun testBookRelativeLink() {
         onNoteInBook(5, R.id.item_head_content_view)
                 .perform(clickClickableSpan("file:./book-b.org"))
+        onView(isRoot()).perform(waitId(R.id.fragment_book_view_flipper, 5000))
         onView(withId(R.id.fragment_book_view_flipper)).check(matches(isDisplayed()))
         onNoteInBook(1, R.id.item_head_title_view).check(matches(withText("Note [b-1]")))
     }
@@ -135,7 +136,7 @@ class InternalLinksTest : OrgzlyTest() {
     fun testNonExistentId() {
         onNoteInBook(6, R.id.item_head_content_view)
             .perform(clickClickableSpan("id:note-with-this-id-does-not-exist"))
-        SystemClock.sleep(500)
+        onView(isRoot()).perform(waitId(com.google.android.material.R.id.snackbar_text, 5000))
         onSnackbar()
             .check(matches(withText("No note or book found with the “ID” property set to “note-with-this-id-does-not-exist”")))
     }
@@ -145,10 +146,14 @@ class InternalLinksTest : OrgzlyTest() {
         onNoteInBook(7, R.id.item_head_content_view)
             .perform(clickClickableSpan("Link to book-b by id"))
 
-        // In book
+        // Wait for book view to load with content
+        onView(isRoot()).perform(waitId(R.id.fragment_book_view_flipper, 5000))
         onView(withId(R.id.fragment_book_view_flipper)).check(matches(isDisplayed()))
 
-        // In book-b
+        // Verify we're in book-b by checking its first note
+        onNoteInBook(1, R.id.item_head_title_view).check(matches(withText("Note [b-1]")))
+
+        // Verify toolbar shows book-b
         onView(allOf(instanceOf(TextView::class.java), withParent(withId(R.id.top_toolbar))))
             .check(matches(withText("book-b")))
     }

--- a/app/src/androidTest/java/com/orgzly/android/espresso/NewNoteTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/NewNoteTest.java
@@ -4,8 +4,10 @@ import androidx.test.core.app.ActivityScenario;
 
 import com.orgzly.R;
 import com.orgzly.android.OrgzlyTest;
+import com.orgzly.android.RetryTestRule;
 import com.orgzly.android.ui.main.MainActivity;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -24,6 +26,9 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.endsWith;
 
 public class NewNoteTest extends OrgzlyTest {
+    @Rule
+    public RetryTestRule mRetryTestRule = new RetryTestRule();
+
     @Test
     public void testNewNoteInEmptyNotebook() {
         testUtils.setupBook("notebook", "");

--- a/app/src/androidTest/java/com/orgzly/android/espresso/NoteEventsTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/NoteEventsTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.orgzly.R
 import com.orgzly.android.OrgzlyTest
+import com.orgzly.android.RetryTestRule
 import com.orgzly.android.espresso.util.EspressoUtils.onBook
 import com.orgzly.android.espresso.util.EspressoUtils.onItemInAgenda
 import com.orgzly.android.espresso.util.EspressoUtils.onNoteInBook
@@ -24,10 +25,14 @@ import com.orgzly.org.datetime.OrgDateTime
 import org.hamcrest.Matchers.not
 import org.hamcrest.Matchers.startsWith
 import org.junit.After
+import org.junit.Rule
 import org.junit.Test
 
 
 class NoteEventsTest : OrgzlyTest() {
+    @get:Rule
+    val retryTestRule = RetryTestRule()
+
     private lateinit var scenario: ActivityScenario<MainActivity>
 
     private val now: String

--- a/app/src/androidTest/java/com/orgzly/android/espresso/NoteEventsTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/NoteEventsTest.kt
@@ -1,7 +1,6 @@
 package com.orgzly.android.espresso
 
 import android.icu.util.Calendar
-import android.os.SystemClock
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -126,7 +125,6 @@ class NoteEventsTest : OrgzlyTest() {
         scenario = ActivityScenario.launch(MainActivity::class.java)
 
         searchForTextCloseKeyboard("ad.1")
-        SystemClock.sleep(500)
         onNotesInAgenda().check(matches(recyclerViewItemCount(2)))
     }
 
@@ -237,7 +235,6 @@ class NoteEventsTest : OrgzlyTest() {
         scenario = ActivityScenario.launch(MainActivity::class.java)
 
         searchForTextCloseKeyboard("ad.2")
-        SystemClock.sleep(500)
         onNotesInAgenda().check(matches(recyclerViewItemCount(2)))
     }
 

--- a/app/src/androidTest/java/com/orgzly/android/espresso/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/NoteFragmentTest.kt
@@ -379,7 +379,6 @@ class NoteFragmentTest : OrgzlyTest() {
                 .check(matches(allOf(withText(userDateTime("[2014-01-01 Wed 20:07]")), isDisplayed())))
         onView(withId(R.id.state_button)).perform(click())
         onView(withText(R.string.clear)).perform(click())
-        SystemClock.sleep(500)
         onView(withId(R.id.closed_button)).check(matches(not(isDisplayed())))
     }
 
@@ -534,7 +533,6 @@ class NoteFragmentTest : OrgzlyTest() {
         onView(withId(R.id.content)).perform(click())
         onView(withId(R.id.content_edit)).perform(typeTextIntoFocusedView("a\nb\nc"))
         onView(withId(R.id.done)).perform(click()) // Note done
-        SystemClock.sleep(1000)
         onNoteInBook(1, R.id.item_head_fold_button).perform(click())
         onNoteInBook(1, R.id.item_head_title_view).check(matches(withText(endsWith("3"))))
     }

--- a/app/src/androidTest/java/com/orgzly/android/espresso/OrgProtocolTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/OrgProtocolTest.kt
@@ -14,10 +14,15 @@ import com.orgzly.android.OrgzlyTest
 import com.orgzly.android.espresso.util.EspressoUtils.onSnackbar
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Matchers.*
+import com.orgzly.android.RetryTestRule
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class OrgProtocolTest : OrgzlyTest() {
+    @get:Rule
+    val retryTestRule = RetryTestRule()
+
     @Before
     @Throws(Exception::class)
     override fun setUp() {

--- a/app/src/androidTest/java/com/orgzly/android/espresso/ReposActivityTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ReposActivityTest.java
@@ -20,15 +20,20 @@ import android.os.SystemClock;
 import com.orgzly.BuildConfig;
 import com.orgzly.R;
 import com.orgzly.android.OrgzlyTest;
+import com.orgzly.android.RetryTestRule;
 import com.orgzly.android.ui.repos.ReposActivity;
 
 import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
 
 public class ReposActivityTest extends OrgzlyTest {
+    @Rule
+    public RetryTestRule mRetryTestRule = new RetryTestRule();
+
     @Test
     public void testSavingWithBogusDirectoryUri() {
         ActivityScenario.launch(ReposActivity.class);

--- a/app/src/androidTest/java/com/orgzly/android/espresso/SavedSearchesFragmentTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/SavedSearchesFragmentTest.java
@@ -35,14 +35,19 @@ import androidx.test.espresso.intent.Intents;
 import com.orgzly.R;
 import com.orgzly.android.LocalStorage;
 import com.orgzly.android.OrgzlyTest;
+import com.orgzly.android.RetryTestRule;
 import com.orgzly.android.ui.main.MainActivity;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
 
 public class SavedSearchesFragmentTest extends OrgzlyTest {
+    @Rule
+    public RetryTestRule mRetryTestRule = new RetryTestRule();
+
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/app/src/androidTest/java/com/orgzly/android/espresso/SettingsChangeTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/SettingsChangeTest.java
@@ -4,9 +4,11 @@ import androidx.test.core.app.ActivityScenario;
 
 import com.orgzly.R;
 import com.orgzly.android.OrgzlyTest;
+import com.orgzly.android.RetryTestRule;
 import com.orgzly.android.ui.main.MainActivity;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static androidx.test.espresso.Espresso.onData;
@@ -28,6 +30,9 @@ import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.not;
 
 public class SettingsChangeTest extends OrgzlyTest {
+    @Rule
+    public RetryTestRule mRetryTestRule = new RetryTestRule();
+
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/app/src/androidTest/java/com/orgzly/android/espresso/ShareActivityTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/ShareActivityTest.kt
@@ -162,8 +162,8 @@ class ShareActivityTest : OrgzlyTest() {
         onView(withId(R.id.content_edit)).check(matches(not(isDisplayed())))
         // Scroll to content_view before isDisplayed() check - keyboard may push it off-screen
         onView(withId(R.id.content_view)).perform(scroll()).check(matches(isDisplayed()))
-        // Title should be in "edit mode"
-        onView(withId(R.id.title_edit)).check(matches(isDisplayed()))
+        // Title should be in "edit mode" — scroll back up after content_view scroll
+        onView(withId(R.id.title_edit)).perform(scroll()).check(matches(isDisplayed()))
         onView(withId(R.id.title_view)).check(matches(not(isDisplayed())))
     }
 

--- a/app/src/androidTest/java/com/orgzly/android/espresso/SshKeyCreationTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/SshKeyCreationTest.kt
@@ -14,14 +14,19 @@ import com.orgzly.BuildConfig
 import com.orgzly.android.OrgzlyTest
 import com.orgzly.android.espresso.util.EspressoUtils
 import com.orgzly.android.ui.main.MainActivity
+import com.orgzly.android.RetryTestRule
+import org.junit.Assume
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.junit.Assume
 
 
 @RunWith(value = Parameterized::class)
 class SshKeyCreationTest(private val param: Parameter) : OrgzlyTest() {
+    @get:Rule
+    val retryTestRule = RetryTestRule()
+
     data class Parameter(val keyType: Int)
     companion object {
         @JvmStatic

--- a/app/src/androidTest/java/com/orgzly/android/espresso/util/EspressoUtils.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/util/EspressoUtils.java
@@ -74,6 +74,15 @@ import java.util.concurrent.TimeoutException;
  */
 public class EspressoUtils {
 
+    private static String resolveIdName(int viewId) {
+        try {
+            return getInstrumentation().getTargetContext()
+                    .getResources().getResourceEntryName(viewId);
+        } catch (Resources.NotFoundException e) {
+            return "<" + viewId + ">";
+        }
+    }
+
 
     public static ViewInteraction onListView() {
         return onView(allOf(isAssignableFrom(ListView.class), isDisplayed()));
@@ -111,6 +120,52 @@ public class EspressoUtils {
             public void describeTo(Description description) {
                 description.appendText(
                         "a RecyclerView adapter which contains " + count + " item(s)");
+            }
+        };
+    }
+
+    /**
+     * Wait until a RecyclerView's adapter has exactly {@code count} items.
+     * Uses UiController to pump the main looper while polling.
+     */
+    public static ViewAction waitForExactAdapterCount(final int count, final long millis) {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return isAssignableFrom(RecyclerView.class);
+            }
+
+            @Override
+            public String getDescription() {
+                return "wait for adapter to have exactly " + count + " item(s) during " + millis + " millis.";
+            }
+
+            @Override
+            public void perform(final UiController uiController, final View view) {
+                uiController.loopMainThreadUntilIdle();
+                final long startTime = System.currentTimeMillis();
+                final long endTime = startTime + millis;
+                final RecyclerView rv = (RecyclerView) view;
+
+                do {
+                    RecyclerView.Adapter<?> adapter = rv.getAdapter();
+                    if (adapter != null && adapter.getItemCount() == count) {
+                        return;
+                    }
+                    uiController.loopMainThreadForAtLeast(50);
+                }
+                while (System.currentTimeMillis() < endTime);
+
+                long elapsed = System.currentTimeMillis() - startTime;
+                RecyclerView.Adapter<?> adapter = rv.getAdapter();
+                int actual = adapter != null ? adapter.getItemCount() : 0;
+                throw new PerformException.Builder()
+                        .withActionDescription(this.getDescription())
+                        .withViewDescription(HumanReadables.describe(view))
+                        .withCause(new TimeoutException(
+                                "Expected exactly " + count + " item(s) but adapter had "
+                                        + actual + " after " + elapsed + "ms"))
+                        .build();
             }
         };
     }
@@ -196,11 +251,56 @@ public class EspressoUtils {
     }
 
     public static ViewInteraction onRecyclerViewItem(@IdRes int recyclerView, int position, @IdRes int childView) {
-        SystemClock.sleep(200);
         onView(isRoot()).perform(waitId(recyclerView, 5000));
+        onView(withId(recyclerView)).perform(waitForAdapterItems(position + 1, 5000));
         onView(withId(recyclerView)).perform(RecyclerViewActions.scrollToPosition(position));
         return onView(new EspressoRecyclerViewMatcher(recyclerView)
                 .atPositionOnView(position, childView));
+    }
+
+    /**
+     * Wait until a RecyclerView's adapter has at least {@code minItems} items.
+     */
+    public static ViewAction waitForAdapterItems(final int minItems, final long millis) {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return isAssignableFrom(RecyclerView.class);
+            }
+
+            @Override
+            public String getDescription() {
+                return "wait for adapter to have at least " + minItems + " item(s) during " + millis + " millis.";
+            }
+
+            @Override
+            public void perform(final UiController uiController, final View view) {
+                uiController.loopMainThreadUntilIdle();
+                final long startTime = System.currentTimeMillis();
+                final long endTime = startTime + millis;
+                final RecyclerView rv = (RecyclerView) view;
+
+                do {
+                    RecyclerView.Adapter<?> adapter = rv.getAdapter();
+                    if (adapter != null && adapter.getItemCount() >= minItems) {
+                        return;
+                    }
+                    uiController.loopMainThreadForAtLeast(50);
+                }
+                while (System.currentTimeMillis() < endTime);
+
+                long elapsed = System.currentTimeMillis() - startTime;
+                RecyclerView.Adapter<?> adapter = rv.getAdapter();
+                int actual = adapter != null ? adapter.getItemCount() : 0;
+                throw new PerformException.Builder()
+                        .withActionDescription(this.getDescription())
+                        .withViewDescription(HumanReadables.describe(view))
+                        .withCause(new TimeoutException(
+                                "Expected at least " + minItems + " item(s) but adapter had "
+                                        + actual + " after " + elapsed + "ms"))
+                        .build();
+            }
+        };
     }
 
     private static class EspressoRecyclerViewMatcher {
@@ -347,14 +447,11 @@ public class EspressoUtils {
     }
 
     public static void searchForTextCloseKeyboard(String str) {
-        SystemClock.sleep(300);
         onView(isRoot()).perform(waitId(R.id.search_view, 5000));
         onView(allOf(withId(R.id.search_view), isDisplayed())).perform(click());
-        SystemClock.sleep(300);
         onView(isRoot()).perform(waitId(R.id.search_src_text, 5000));
         onView(withId(R.id.search_src_text)).perform(replaceText(str), pressKey(KeyEvent.KEYCODE_ENTER));
         closeSoftKeyboardWithDelay();
-        SystemClock.sleep(300);
     }
 
     public static ViewAction[] replaceTextCloseKeyboard(String str) {
@@ -485,7 +582,7 @@ public class EspressoUtils {
 
             @Override
             public String getDescription() {
-                return "wait for a specific view with id <" + viewId + "> during " + millis + " millis.";
+                return "wait for view " + resolveIdName(viewId) + " during " + millis + " millis.";
             }
 
             @Override
@@ -507,11 +604,13 @@ public class EspressoUtils {
                 }
                 while (System.currentTimeMillis() < endTime);
 
-                // timeout happens
+                long elapsed = System.currentTimeMillis() - startTime;
                 throw new PerformException.Builder()
                         .withActionDescription(this.getDescription())
                         .withViewDescription(HumanReadables.describe(view))
-                        .withCause(new TimeoutException())
+                        .withCause(new TimeoutException(
+                                "View " + resolveIdName(viewId)
+                                        + " not found after " + elapsed + "ms"))
                         .build();
             }
         };

--- a/app/src/androidTest/java/com/orgzly/android/util/AgendaUtilsTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/util/AgendaUtilsTest.kt
@@ -11,6 +11,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.util.*
 
+// Cannot move to JVM: AgendaItems transitively loads NoteView (Room entity),
+// which causes SIGSEGV on Temurin 17 JVM.
 @RunWith(value = Parameterized::class)
 class AgendaUtilsTest(private val param: Parameter) {
 

--- a/app/src/test/java/com/orgzly/android/RetryTestRule.kt
+++ b/app/src/test/java/com/orgzly/android/RetryTestRule.kt
@@ -9,7 +9,7 @@ import org.junit.runners.model.Statement
 /**
  * Used for retrying flaky tests.
  */
-class RetryTestRule(val retryCount: Int = 10) : TestRule {
+class RetryTestRule(val retryCount: Int = 3) : TestRule {
 
     private val TAG = RetryTestRule::class.java.simpleName
 


### PR DESCRIPTION
Its hard to optimise anything when there is always different test which is failing. Hopefully this stabilises things a bit. It seems that something emulator is simply stuck, for that cases, tests needs to be run again after timeout of 60 minutes.

## Summary

- **Improve EspressoUtils wait utilities** — add `resolveIdName()` for human-readable timeout errors, `waitForAdapterItems()` in `onRecyclerViewItem` to prevent scroll-before-populate races, `waitForExactAdapterCount()` for precise adapter assertions, and remove redundant sleeps in shared helpers
- **Fix flaky Espresso tests** — replace blind `SystemClock.sleep()` with deterministic `waitId` polling in InternalLinksTest, ExternalLinksTest, NoteEventsTest, NoteFragmentTest, GitRepoTest, AgendaFragmentTest, ActionModeTest, and ShareActivityTest
- **Add RetryTestRule to all Espresso test classes** — 13 classes were missing it; also reduce JVM RetryTestRule default from 10 to 3 to match androidTest
- **CI improvements** — 60-minute job timeout (was GitHub's default 360m), `fail-fast: false` so one flaky job doesn't cancel the other 3 matrix entries

Best reviewed commit by commit.

## Test plan

- [x] 5 consecutive green CI runs across all matrix configurations (API 29+35, Fdroid+Premium)
- [x] Compilation verified locally via `assembleFdroidDebugAndroidTest`