### PR TITLE
CI: stabilize AVD snapshot with service wait before save

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,7 +87,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: avd-v2-${{ matrix.api-level }}
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -100,7 +100,11 @@ jobs:
           disable-animations: true
           disable-spellchecker: true
           profile: Nexus 6
-          script: echo "Generated AVD snapshot for caching."
+          script: |
+            echo "Waiting for system services to stabilize..."
+            adb shell input keyevent 82
+            sleep 10
+            echo "Generated AVD snapshot for caching."
 
       - name: Save AVD to cache
         if: always() && steps.avd-cache.outputs.cache-hit != 'true'
@@ -109,7 +113,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: avd-v2-${{ matrix.api-level }}
 
       - name: Add Dropbox API TEST credentials
         shell: bash


### PR DESCRIPTION
## Summary

- Add 10s stabilization wait + `input keyevent 82` before saving AVD snapshot
- Bump cache key to `avd-v2-*` to invalidate stale snapshots

## Problem

All Espresso tests on API 35 fail with `RootViewWithoutFocusException` — the emulator window never receives focus. The AVD snapshot was saved immediately after boot, before system services were fully registered. Upstream's `avd-35` cache dates back to December 2025; on restore, the emulator boots into a broken state.

API 29 passes because its lighter image stabilizes faster.

## Test plan

- [ ] API 35 Fdroid and Premium instrumented tests pass
- [ ] API 29 tests still pass (regression check)