### PR TITLE
Raise minimum Android API to 23 (Android 6)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 36
         versionCode 277
         versionName "1.19.0-beta.1"

--- a/app/src/androidTest/java/com/orgzly/android/espresso/AgendaFragmentTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/AgendaFragmentTest.java
@@ -33,6 +33,7 @@ import androidx.test.espresso.contrib.PickerActions;
 
 import com.orgzly.R;
 import com.orgzly.android.OrgzlyTest;
+import com.orgzly.android.RetryTestRule;
 import com.orgzly.android.espresso.util.EspressoUtils;
 import com.orgzly.android.prefs.AppPreferences;
 import com.orgzly.android.ui.main.MainActivity;
@@ -40,10 +41,14 @@ import com.orgzly.android.ui.main.MainActivity;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class AgendaFragmentTest extends OrgzlyTest {
     private ActivityScenario<MainActivity> scenario;
+
+    @Rule
+    public RetryTestRule mRetryTestRule = new RetryTestRule();
 
     private ActivityScenario<MainActivity> defaultSetUp() {
         testUtils.setupBook("book-one",

--- a/app/src/androidTest/java/com/orgzly/android/espresso/BooksTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/BooksTest.java
@@ -152,9 +152,6 @@ public class BooksTest extends OrgzlyTest {
 
     @Test
     public void testExportWithFakeResponse() {
-        // Only if DocumentsProvider is supported
-        assumeTrue(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT);
-
         onBook(0).perform(longClick());
         contextualToolbarOverflowMenu().perform(click());
 
@@ -180,18 +177,6 @@ public class BooksTest extends OrgzlyTest {
         file.delete();
 
         Intents.release();
-    }
-
-    @Test
-    public void testExport() throws IOException {
-        // Older API versions, when file is saved in Download/
-        assumeTrue(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT);
-
-        onBook(0).perform(longClick());
-        contextualToolbarOverflowMenu().perform(click());
-        onView(withText(R.string.export)).perform(click());
-        onSnackbar().check(matches(withText(startsWith(context.getString(R.string.book_exported, "")))));
-        localStorage.getExportFile("book-1", BookFormat.ORG).delete();
     }
 
     @Test

--- a/app/src/main/java/com/orgzly/android/NotificationBroadcastReceiver.kt
+++ b/app/src/main/java/com/orgzly/android/NotificationBroadcastReceiver.kt
@@ -4,11 +4,9 @@ import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import com.orgzly.BuildConfig
-import com.orgzly.android.data.logs.AppLogsRepository
-import com.orgzly.android.reminders.RemindersScheduler
 import com.orgzly.android.reminders.AlarmSoundService
+import com.orgzly.android.reminders.RemindersScheduler
 import com.orgzly.android.ui.notifications.Notifications
 import com.orgzly.android.ui.util.getNotificationManager
 import com.orgzly.android.usecase.NoteUpdateStateDone
@@ -67,17 +65,15 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
     }
 
     private fun cancelRemindersSummary(notificationManager: NotificationManager) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val notifications = notificationManager.activeNotifications
-            var reminders = 0
-            for (notification in notifications) {
-                if (notification.id == Notifications.REMINDER_ID) {
-                    reminders++
-                }
+        val notifications = notificationManager.activeNotifications
+        var reminders = 0
+        for (notification in notifications) {
+            if (notification.id == Notifications.REMINDER_ID) {
+                reminders++
             }
-            if (reminders == 0) {
-                notificationManager.cancel(Notifications.REMINDERS_SUMMARY_ID)
-            }
+        }
+        if (reminders == 0) {
+            notificationManager.cancel(Notifications.REMINDERS_SUMMARY_ID)
         }
     }
 

--- a/app/src/main/java/com/orgzly/android/prefs/TimePreferenceFragment.kt
+++ b/app/src/main/java/com/orgzly/android/prefs/TimePreferenceFragment.kt
@@ -1,7 +1,6 @@
 package com.orgzly.android.prefs
 
 
-import android.os.Build
 import android.os.Bundle
 import android.text.format.DateFormat
 import android.view.View
@@ -27,32 +26,18 @@ class TimePreferenceFragment : PreferenceDialogFragmentCompat() {
 
             setIs24HourView(is24hour)
 
-            @Suppress("DEPRECATION")
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                hour = hours
-                minute = minutes
-            } else {
-                currentHour = hours
-                currentMinute = minutes
-            }
+            hour = hours
+            minute = minutes
         }
     }
 
     override fun onDialogClosed(positiveResult: Boolean) {
         if (positiveResult) {
             @Suppress("DEPRECATION")
-            val hours = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                timePicker.hour
-            } else {
-                timePicker.currentHour
-            }
+            val hours = timePicker.hour
 
             @Suppress("DEPRECATION")
-            val minutes = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                timePicker.minute
-            } else {
-                timePicker.currentMinute
-            }
+            val minutes = timePicker.minute
 
             val minutesAfterMidnight = hours * 60 + minutes
 

--- a/app/src/main/java/com/orgzly/android/prefs/TimePreferenceFragment.kt
+++ b/app/src/main/java/com/orgzly/android/prefs/TimePreferenceFragment.kt
@@ -33,10 +33,8 @@ class TimePreferenceFragment : PreferenceDialogFragmentCompat() {
 
     override fun onDialogClosed(positiveResult: Boolean) {
         if (positiveResult) {
-            @Suppress("DEPRECATION")
             val hours = timePicker.hour
 
-            @Suppress("DEPRECATION")
             val minutes = timePicker.minute
 
             val minutesAfterMidnight = hours * 60 + minutes

--- a/app/src/main/java/com/orgzly/android/reminders/RemindersScheduler.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/RemindersScheduler.kt
@@ -103,11 +103,6 @@ class RemindersScheduler @Inject constructor(val context: Application, val logs:
             // probably a daily reminder. Schedule an inexact alarm.
             scheduleInExact(alarmManager, intent, inMs, origin)
         }
-
-        // Intent received, notifications not displayed by default
-        // Note: Neither setAndAllowWhileIdle() nor setExactAndAllowWhileIdle() can fire
-        // alarms more than once per 9 minutes, per app.
-        // scheduleExactAndAllowWhileIdle(context, intent, inMs)
     }
 
     private fun scheduleAlarmClock(alarmManager: AlarmManager, intent: PendingIntent, inMs: Long, origin: String) {
@@ -115,15 +110,7 @@ class RemindersScheduler @Inject constructor(val context: Application, val logs:
         alarmManager.setAlarmClock(info, intent)
         logScheduled("setAlarmClock", origin, inMs)
     }
-
-    private fun scheduleExact(alarmManager: AlarmManager, intent: PendingIntent, inMs: Long, origin: String) {
-        alarmManager.setExact(
-            AlarmManager.ELAPSED_REALTIME_WAKEUP,
-            SystemClock.elapsedRealtime() + inMs,
-            intent)
-        logScheduled("setExact", origin, inMs)
-    }
-
+   
     private fun scheduleInExact(alarmManager: AlarmManager, intent: PendingIntent, inMs: Long, origin: String) {
         alarmManager.set(
             AlarmManager.ELAPSED_REALTIME_WAKEUP,

--- a/app/src/main/java/com/orgzly/android/reminders/RemindersScheduler.kt
+++ b/app/src/main/java/com/orgzly/android/reminders/RemindersScheduler.kt
@@ -9,7 +9,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.SystemClock
 import android.util.Log
-import androidx.annotation.RequiresApi
 import com.orgzly.android.App
 import com.orgzly.android.AppIntent
 import com.orgzly.android.data.logs.AppLogsRepository
@@ -97,11 +96,7 @@ class RemindersScheduler @Inject constructor(val context: Application, val logs:
             if (AppPreferences.remindersUseAlarmClockForTodReminders(context)) {
                 scheduleAlarmClock(alarmManager, intent, inMs, origin)
             } else {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    scheduleExactAndAllowWhileIdle(alarmManager, intent, inMs, origin)
-                } else {
-                    scheduleExact(alarmManager, intent, inMs, origin)
-                }
+                scheduleExactAndAllowWhileIdle(alarmManager, intent, inMs, origin)
             }
         } else {
             // This reminder does not contain clock time information; it's
@@ -137,7 +132,6 @@ class RemindersScheduler @Inject constructor(val context: Application, val logs:
         logScheduled("set", origin, inMs)
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun scheduleExactAndAllowWhileIdle(alarmManager: AlarmManager, intent: PendingIntent, inMs: Long, origin: String) {
         alarmManager.setExactAndAllowWhileIdle(
             AlarmManager.ELAPSED_REALTIME_WAKEUP,

--- a/app/src/main/java/com/orgzly/android/ui/CommonActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/CommonActivity.kt
@@ -117,17 +117,15 @@ abstract class CommonActivity : AppCompatActivity() {
     private fun baseContext(newBase: Context): Context {
         var context = newBase
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            val config = Configuration(newBase.resources.configuration)
+        val config = Configuration(newBase.resources.configuration)
 
-            if (AppPreferences.ignoreSystemLocale(context)) {
-                config.setLocale(Locale.US)
-            } else {
-                config.setLocale(Locale.getDefault())
-            }
-
-            context = context.createConfigurationContext(config)
+        if (AppPreferences.ignoreSystemLocale(context)) {
+            config.setLocale(Locale.US)
+        } else {
+            config.setLocale(Locale.getDefault())
         }
+
+        context = context.createConfigurationContext(config)
 
         return context
     }

--- a/app/src/main/java/com/orgzly/android/ui/SshKeygenActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/SshKeygenActivity.kt
@@ -84,11 +84,7 @@ class SshKeygenActivity : CommonActivity() {
                 }
             }
             val keyguardManager: KeyguardManager = getSystemService(KEYGUARD_SERVICE) as KeyguardManager
-            keyRequireAuthentication.isEnabled = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-                false
-            } else {
-                keyguardManager.isDeviceSecure
-            }
+            keyRequireAuthentication.isEnabled = keyguardManager.isDeviceSecure
             keyRequireAuthentication.isChecked = keyRequireAuthentication.isEnabled
         }
     }

--- a/app/src/main/java/com/orgzly/android/ui/util/ActivityUtils.kt
+++ b/app/src/main/java/com/orgzly/android/ui/util/ActivityUtils.kt
@@ -149,11 +149,7 @@ object ActivityUtils {
 
     @JvmStatic
     fun immutable(flags: Int): Int {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            flags or PendingIntent.FLAG_IMMUTABLE
-        } else {
-            flags
-        }
+        return flags or PendingIntent.FLAG_IMMUTABLE
     }
 
     @JvmStatic

--- a/app/src/main/java/com/orgzly/android/ui/util/Extensions.kt
+++ b/app/src/main/java/com/orgzly/android/ui/util/Extensions.kt
@@ -48,19 +48,6 @@ private fun haveNetworkConnection(cm: ConnectivityManager): Boolean {
     return capabilities != null && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
 }
 
-@Suppress("DEPRECATION")
-private fun haveNetworkConnectionPreM(cm: ConnectivityManager): Boolean {
-    val networkInfo = cm.activeNetworkInfo
-
-    if (networkInfo != null) {
-        val type = networkInfo.type
-
-        return type == ConnectivityManager.TYPE_WIFI || type == ConnectivityManager.TYPE_MOBILE
-    }
-
-    return false
-}
-
 @SuppressLint("ResourceType")
 fun SwipeRefreshLayout.setup() {
     setOnRefreshListener {

--- a/app/src/main/java/com/orgzly/android/ui/util/Extensions.kt
+++ b/app/src/main/java/com/orgzly/android/ui/util/Extensions.kt
@@ -1,12 +1,10 @@
 package com.orgzly.android.ui.util
 
 import android.annotation.SuppressLint
-import android.annotation.TargetApi
 import android.content.Context
 import android.content.res.TypedArray
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import android.os.Build
 import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.StyleableRes
@@ -39,14 +37,9 @@ fun <R> Context.styledAttributes(set: AttributeSet, @StyleableRes attrs: IntArra
  * Determines if there is internet connection available.
  */
 fun Context.haveNetworkConnection(): Boolean {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        haveNetworkConnection(getConnectivityManager())
-    } else {
-        haveNetworkConnectionPreM(getConnectivityManager())
-    }
+    return haveNetworkConnection(getConnectivityManager())
 }
 
-@TargetApi(Build.VERSION_CODES.M)
 private fun haveNetworkConnection(cm: ConnectivityManager): Boolean {
     val network = cm.activeNetwork
 


### PR DESCRIPTION
This means the app will no longer run on on Android 5 and older.

"Starting in June 2025, new releases of many AndroidX libraries
previously targeting minSdk 21 will be updated to require minSdk 23."

-- https://developer.android.com/jetpack/androidx/versions#version-table

Closes issue #769.