### PR TITLE
feat(calendar): add week and month views in new Calendar section

### DIFF
--- a/app/src/main/java/com/orgzly/android/AppIntent.java
+++ b/app/src/main/java/com/orgzly/android/AppIntent.java
@@ -32,6 +32,7 @@ public class AppIntent {
     public static final String ACTION_FOLLOW_LINK_TO_FILE = "com.orgzly.intent.action.FOLLOW_LINK_TO_FILE";
     public static final String ACTION_OPEN_SAVED_SEARCHES = "com.orgzly.intent.action.OPEN_SAVED_SEARCHES";
     public static final String ACTION_OPEN_QUERY = "com.orgzly.intent.action.OPEN_QUERY";
+    public static final String ACTION_OPEN_CALENDAR = "com.orgzly.intent.action.OPEN_CALENDAR";
     public static final String ACTION_OPEN_BOOKS = "com.orgzly.intent.action.OPEN_BOOKS";
     public static final String ACTION_OPEN_BOOK = "com.orgzly.intent.action.OPEN_BOOK";
     public static final String ACTION_OPEN_SETTINGS = "com.orgzly.intent.action.OPEN_SETTINGS";

--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -939,6 +939,24 @@ public class AppPreferences {
                 context.getResources().getBoolean(R.bool.pref_default_group_scheduled_with_today));
     }
 
+    public static int calendarTextSize(Context context) {
+        return Integer.parseInt(getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_calendar_month_text_size),
+                context.getResources().getString(R.string.pref_default_calendar_month_text_size)));
+    }
+
+    public static boolean calendarShowBookName(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_calendar_show_book_name),
+                context.getResources().getBoolean(R.bool.pref_default_calendar_show_book_name));
+    }
+
+    public static String calendarFirstDayOfWeek(Context context) {
+        return getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_calendar_first_day_of_week),
+                context.getResources().getString(R.string.pref_default_calendar_first_day_of_week));
+    }
+
     public static void groupScheduledWithTodayInAgenda(Context context, boolean value) {
         getDefaultSharedPreferences(context).edit().putBoolean(
                 context.getResources().getString(R.string.pref_key_group_scheduled_with_today),

--- a/app/src/main/java/com/orgzly/android/ui/DisplayManager.java
+++ b/app/src/main/java/com/orgzly/android/ui/DisplayManager.java
@@ -221,6 +221,17 @@ public class DisplayManager {
                 true);
     }
 
+    public static void displayCalendar(FragmentManager fragmentManager) {
+        Fragment fragment = AgendaFragment.getCalendarInstance();
+
+        replaceFragment(
+                fragmentManager,
+                R.id.single_pane_container,
+                fragment,
+                AgendaFragment.FRAGMENT_TAG,
+                true);
+    }
+
     public static void displayEditor(FragmentManager fragmentManager, Book book) {
         Fragment fragment = BookPrefaceFragment.Companion.getInstance(book.getId(), book.getPreface());
 

--- a/app/src/main/java/com/orgzly/android/ui/drawer/DrawerNavigationView.kt
+++ b/app/src/main/java/com/orgzly/android/ui/drawer/DrawerNavigationView.kt
@@ -14,6 +14,7 @@ import com.orgzly.android.db.entity.SavedSearch
 import com.orgzly.android.ui.books.BooksFragment
 import com.orgzly.android.ui.main.MainActivity
 import com.orgzly.android.ui.main.MainActivityViewModel
+import com.orgzly.android.ui.notes.query.agenda.AgendaFragment
 import com.orgzly.android.ui.notes.book.BookFragment
 import com.orgzly.android.ui.notes.query.QueryFragment
 import com.orgzly.android.ui.savedsearches.SavedSearchesFragment
@@ -36,10 +37,12 @@ internal class DrawerNavigationView(
         // Add mapping for groups
         menuItemIdMap[BooksFragment.drawerItemId] = R.id.books
         menuItemIdMap[SavedSearchesFragment.getDrawerItemId()] = R.id.searches
+        menuItemIdMap[AgendaFragment.getCalendarDrawerItemId()] = R.id.calendar
 
         // Setup intents
         menu.findItem(R.id.searches).intent = Intent(AppIntent.ACTION_OPEN_SAVED_SEARCHES)
         menu.findItem(R.id.books).intent = Intent(AppIntent.ACTION_OPEN_BOOKS)
+        menu.findItem(R.id.calendar).intent = Intent(AppIntent.ACTION_OPEN_CALENDAR)
         menu.findItem(R.id.settings).intent = Intent(AppIntent.ACTION_OPEN_SETTINGS)
 
         viewModel.books().observe(activity, Observer {

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -632,6 +632,7 @@ public class MainActivity extends CommonActivity
         bm.registerReceiver(receiver, new IntentFilter(AppIntent.ACTION_FOLLOW_LINK_TO_FILE));
         bm.registerReceiver(receiver, new IntentFilter(AppIntent.ACTION_OPEN_SAVED_SEARCHES));
         bm.registerReceiver(receiver, new IntentFilter(AppIntent.ACTION_OPEN_QUERY));
+        bm.registerReceiver(receiver, new IntentFilter(AppIntent.ACTION_OPEN_CALENDAR));
         bm.registerReceiver(receiver, new IntentFilter(AppIntent.ACTION_OPEN_BOOKS));
         bm.registerReceiver(receiver, new IntentFilter(AppIntent.ACTION_OPEN_BOOK));
         bm.registerReceiver(receiver, new IntentFilter(AppIntent.ACTION_OPEN_SETTINGS));
@@ -999,6 +1000,11 @@ public class MainActivity extends CommonActivity
                     String query = intent.getStringExtra(AppIntent.EXTRA_QUERY_STRING);
                     String searchName = intent.getStringExtra(AppIntent.EXTRA_SEARCH_NAME);
                     DisplayManager.displayQuery(getSupportFragmentManager(), query, searchName);
+                    break;
+                }
+
+                case AppIntent.ACTION_OPEN_CALENDAR: {
+                    DisplayManager.displayCalendar(getSupportFragmentManager());
                     break;
                 }
 

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
@@ -2,10 +2,15 @@ package com.orgzly.android.ui.notes.query.agenda
 
 import android.content.Intent
 import android.os.Bundle
+import android.text.format.DateUtils
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.GridLayout
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -13,10 +18,12 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.orgzly.BuildConfig
 import com.orgzly.R
+import com.orgzly.android.db.entity.NoteView
 import com.orgzly.android.prefs.AppPreferences
 import com.orgzly.android.sync.SyncRunner
 import com.orgzly.android.ui.OnViewHolderClickListener
 import com.orgzly.android.ui.SelectableItemAdapter
+import com.orgzly.android.ui.TimeType
 import com.orgzly.android.ui.main.setupSearchView
 import com.orgzly.android.ui.notes.ItemGestureDetector
 import com.orgzly.android.ui.notes.NoteItemViewHolder
@@ -33,6 +40,10 @@ import com.orgzly.android.ui.util.setDecorFitsSystemWindowsForBottomToolbar
 import com.orgzly.android.ui.util.setup
 import com.orgzly.android.util.LogUtils
 import com.orgzly.databinding.FragmentQueryAgendaBinding
+import org.joda.time.DateTime
+import org.joda.time.DateTimeConstants
+import java.text.DateFormatSymbols
+import java.util.Locale
 
 
 /**
@@ -42,8 +53,31 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
     private lateinit var binding: FragmentQueryAgendaBinding
 
     private val item2databaseIds = hashMapOf<Long, Long>()
+    private val monthItem2databaseIds = hashMapOf<Long, Long>()
 
     lateinit var viewAdapter: AgendaAdapter
+    lateinit var monthViewAdapter: AgendaAdapter
+
+    private enum class DisplayMode {
+        AGENDA,
+        WEEK,
+        MONTH
+    }
+
+    private var displayMode = DisplayMode.AGENDA
+    private var isCalendarMode = false
+    private var currentMonth: DateTime = DateTime.now().withTimeAtStartOfDay().withDayOfMonth(1)
+    private var currentWeekStart: DateTime = DateTime.now().withTimeAtStartOfDay()
+    private var selectedMonthDay: DateTime = DateTime.now().withTimeAtStartOfDay()
+    private var calendarItemsByDay = linkedMapOf<Long, MutableList<AgendaItem.Note>>()
+
+    private data class DayEvent(
+        val noteId: Long,
+        val title: String,
+        val bookName: String,
+        val timeLabel: String?,
+        val agendaItem: AgendaItem.Note
+    )
 
     private val appBarBackPressHandler = object : OnBackPressedCallback(false) {
         override fun handleOnBackPressed() {
@@ -52,11 +86,17 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
     }
 
     override fun getAdapter(): SelectableItemAdapter? {
-        return if (::viewAdapter.isInitialized) viewAdapter else null
+        return if (::viewAdapter.isInitialized) getActiveAdapter() else null
+    }
+
+    override fun getCurrentDrawerItemId(): String {
+        return if (isCalendarMode) getCalendarDrawerItemId() else super.getCurrentDrawerItemId()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        isCalendarMode = requireArguments().getBoolean(ARG_CALENDAR_MODE, false)
+        currentWeekStart = weekStartFor(DateTime.now().withTimeAtStartOfDay())
 
         requireActivity().onBackPressedDispatcher.addCallback(this, appBarBackPressHandler)
         requireActivity().onBackPressedDispatcher.addCallback(this, notePopupDismissOnBackPress)
@@ -75,6 +115,8 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
         viewAdapter = AgendaAdapter(binding.root.context, this)
         viewAdapter.setHasStableIds(true)
+        monthViewAdapter = AgendaAdapter(binding.root.context, this)
+        monthViewAdapter.setHasStableIds(true)
 
         // Restores selection, requires adapter
         super.onViewCreated(view, savedInstanceState)
@@ -106,17 +148,83 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
             }))
         }
 
+        binding.monthDayEventsRecyclerView.let { rv ->
+            val monthLayoutManager = StickyHeadersLinearLayoutManager<AgendaAdapter>(
+                context, LinearLayoutManager.VERTICAL, false
+            )
+            rv.layoutManager = monthLayoutManager
+            rv.adapter = monthViewAdapter
+            rv.addItemDecoration(DividerItemDecoration(context, monthLayoutManager.orientation))
+        }
+
+        binding.monthPrevButton.setOnClickListener {
+            when (displayMode) {
+                DisplayMode.MONTH -> {
+                    currentMonth = currentMonth.minusMonths(1)
+                    if (!isSameMonth(selectedMonthDay, currentMonth)) {
+                        selectedMonthDay = currentMonth
+                    }
+                    renderMonthView()
+                }
+                DisplayMode.WEEK -> {
+                    currentWeekStart = currentWeekStart.minusWeeks(1)
+                    renderWeekView()
+                }
+                DisplayMode.AGENDA -> {}
+            }
+        }
+
+        binding.monthNextButton.setOnClickListener {
+            when (displayMode) {
+                DisplayMode.MONTH -> {
+                    currentMonth = currentMonth.plusMonths(1)
+                    if (!isSameMonth(selectedMonthDay, currentMonth)) {
+                        selectedMonthDay = currentMonth
+                    }
+                    renderMonthView()
+                }
+                DisplayMode.WEEK -> {
+                    currentWeekStart = currentWeekStart.plusWeeks(1)
+                    renderWeekView()
+                }
+                DisplayMode.AGENDA -> {}
+            }
+        }
+
+        binding.viewModeAgendaButton.setOnClickListener {
+            displayMode = DisplayMode.AGENDA
+            updateDisplayMode()
+        }
+        binding.viewModeWeekButton.setOnClickListener {
+            displayMode = DisplayMode.WEEK
+            updateDisplayMode()
+        }
+        binding.viewModeMonthButton.setOnClickListener {
+            displayMode = DisplayMode.MONTH
+            updateDisplayMode()
+        }
+        binding.viewModeTodayButton.setOnClickListener {
+            goToToday()
+        }
+
+        binding.calendarControlsContainer.post {
+            updateDisplayMode()
+        }
+
         binding.swipeContainer.setup()
     }
 
     override fun onResume() {
         super.onResume()
 
-        sharedMainActivityViewModel.setCurrentFragment(FRAGMENT_TAG)
+        sharedMainActivityViewModel.setCurrentFragment(
+            if (isCalendarMode) getCalendarDrawerItemId() else FRAGMENT_TAG
+        )
     }
 
     private fun topToolbarToDefault() {
         viewAdapter.clearSelection()
+        monthViewAdapter.clearSelection()
 
         binding.topToolbar.run {
             menu.clear()
@@ -153,8 +261,8 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
                 binding.topToolbar.menu.findItem(R.id.search_view)?.expandActionView()
             }
 
-            title = currentQueryName ?: getString(R.string.agenda)
-            subtitle = currentQuery
+            title = if (isCalendarMode) getString(R.string.calendar) else (currentQueryName ?: getString(R.string.agenda))
+            subtitle = if (isCalendarMode) null else currentQuery
         }
     }
 
@@ -165,6 +273,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
     }
 
     private fun topToolbarToMainSelection() {
+        val activeAdapter = getActiveAdapter()
         binding.topToolbar.run {
             menu.clear()
             inflateMenu(R.menu.query_cab_top)
@@ -176,29 +285,30 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
             }
 
             setOnMenuItemClickListener { menuItem ->
-                handleActionItemClick(viewAdapter.getSelection().getIds(), menuItem.itemId)
+                handleActionItemClick(activeAdapter.getSelection().getIds(), menuItem.itemId)
                 true
             }
 
             // Number of selected notes as a title
-            title = viewAdapter.getSelection().count.toString()
+            title = activeAdapter.getSelection().count.toString()
             subtitle = null
         }
     }
 
     private fun bottomToolbarToMainSelection() {
+        val activeAdapter = getActiveAdapter()
         binding.bottomToolbar.run {
             menu.clear()
             inflateMenu(R.menu.query_cab_bottom)
 
             setOnMenuItemClickListener { menuItem ->
-                handleActionItemClick(viewAdapter.getSelection().getIds(), menuItem.itemId)
+                handleActionItemClick(activeAdapter.getSelection().getIds(), menuItem.itemId)
                 true
             }
 
             // Hide buttons that can't be used when multiple notes are selected
             listOf(R.id.focus).forEach { id ->
-                menu.findItem(id)?.isVisible = viewAdapter.getSelection().count == 1
+                menu.findItem(id)?.isVisible = activeAdapter.getSelection().count == 1
             }
 
             visibility = View.VISIBLE
@@ -228,7 +338,6 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
         viewModel.data.observe(viewLifecycleOwner, Observer { notes ->
             if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, "Observed notes: ${notes.size}")
-
             val hideEmptyDaysInAgenda = AppPreferences.hideEmptyDaysInAgenda(context)
             val groupScheduledWithToday = AppPreferences.groupScheduledWithTodayInAgenda(context)
             val items = AgendaItems(
@@ -240,14 +349,18 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
                 LogUtils.d(TAG, "Replacing data with ${items.size} agenda items")
 
             viewAdapter.submitList(items)
+            recomputeMonthItems(notes)
 
             val ids = notes.mapTo(hashSetOf()) { it.note.id }
 
             viewAdapter.getSelection().removeNonExistent(ids)
+            monthViewAdapter.getSelection().removeNonExistent(ids)
 
             viewAdapter.getSelection().setMap(item2databaseIds)
+            monthViewAdapter.getSelection().setMap(monthItem2databaseIds)
 
-            viewModel.appBar.toModeFromSelectionCount(viewAdapter.getSelection().count)
+            viewModel.appBar.toModeFromSelectionCount(getActiveAdapter().getSelection().count)
+            updateDisplayMode()
         })
 
         viewModel.appBar.mode.observeSingle(viewLifecycleOwner) { mode ->
@@ -255,6 +368,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
                 APP_BAR_DEFAULT_MODE -> {
                     topToolbarToDefault()
                     bottomToolbarToDefault()
+                    updateDisplayMode()
 
                     sharedMainActivityViewModel.unlockDrawer()
 
@@ -277,7 +391,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
     override fun onClick(view: View, position: Int, item: AgendaItem) {
         if (!AppPreferences.isReverseNoteClickAction(context)) {
-            if (viewAdapter.getSelection().count > 0) {
+            if (getActiveAdapter().getSelection().count > 0) {
                 toggleNoteSelection(position, item)
             } else {
                 openNote(item)
@@ -305,11 +419,434 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
     private fun toggleNoteSelection(position: Int, item: AgendaItem) {
         if (item is AgendaItem.Note) {
-            viewAdapter.getSelection().toggle(item.id)
-            viewAdapter.notifyItemChanged(position)
+            val activeAdapter = getActiveAdapter()
+            activeAdapter.getSelection().toggle(item.id)
+            activeAdapter.notifyItemChanged(position)
 
-            viewModel.appBar.toModeFromSelectionCount(viewAdapter.getSelection().count)
+            viewModel.appBar.toModeFromSelectionCount(activeAdapter.getSelection().count)
         }
+    }
+
+    // Calendar display modes
+    private fun getActiveAdapter(): AgendaAdapter {
+        return if (displayMode == DisplayMode.AGENDA) viewAdapter else monthViewAdapter
+    }
+
+    private fun updateDisplayMode() {
+        if (!::binding.isInitialized) return
+        binding.calendarControlsContainer.visibility = if (isCalendarMode) View.VISIBLE else View.GONE
+
+        currentWeekStart = weekStartFor(currentWeekStart)
+        updateModeButtons()
+        val controlsHeight = binding.calendarControlsContainer.height
+        binding.fragmentQueryAgendaMonthContainer.setPadding(0, controlsHeight, 0, 0)
+
+        when (displayMode) {
+            DisplayMode.AGENDA -> {
+                binding.fragmentQueryAgendaRecyclerView.visibility = View.VISIBLE
+                binding.fragmentQueryAgendaMonthContainer.visibility = View.GONE
+            }
+            DisplayMode.WEEK -> {
+                binding.fragmentQueryAgendaRecyclerView.visibility = View.GONE
+                binding.fragmentQueryAgendaMonthContainer.visibility = View.VISIBLE
+                renderWeekView()
+            }
+            DisplayMode.MONTH -> {
+                binding.fragmentQueryAgendaRecyclerView.visibility = View.GONE
+                binding.fragmentQueryAgendaMonthContainer.visibility = View.VISIBLE
+                renderMonthView()
+            }
+        }
+        updateTodayButtonState()
+    }
+
+    // Month view
+    private fun renderMonthView() {
+        binding.monthGrid.visibility = View.VISIBLE
+        binding.monthDayEventsRecyclerView.visibility = View.GONE
+        binding.weekColumnsContainer.visibility = View.GONE
+
+        binding.monthLabel.text = DateUtils.formatDateTime(
+            context,
+            currentMonth.millis,
+            DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_NO_MONTH_DAY
+        )
+
+        val monthStart = currentMonth.withDayOfMonth(1).withTimeAtStartOfDay()
+        val monthEnd = monthStart.plusMonths(1).minusDays(1).withTimeAtStartOfDay()
+
+        if (selectedMonthDay.isBefore(monthStart) || selectedMonthDay.isAfter(monthEnd)) {
+            selectedMonthDay = monthStart
+        }
+
+        renderMonthGrid()
+        updateTodayButtonState()
+    }
+
+    private fun renderMonthGrid() {
+        val grid = binding.monthGrid
+        grid.removeAllViews()
+
+        val textSize = AppPreferences.calendarTextSize(requireContext()).toFloat()
+        val showBookName = AppPreferences.calendarShowBookName(requireContext())
+
+        val firstDay = currentMonth.withDayOfMonth(1).withTimeAtStartOfDay()
+        val firstDayOfWeek = firstDayOfWeek()
+        val offset = (7 + firstDay.dayOfWeek - firstDayOfWeek) % 7
+        val gridStart = firstDay.minusDays(offset)
+
+        val dayLabels = DateFormatSymbols(Locale.getDefault()).shortWeekdays
+
+        repeat(7) { i ->
+            val label = TextView(requireContext()).apply {
+                text = dayLabels[(firstDayOfWeek + i) % 7 + 1]
+                gravity = Gravity.CENTER
+                setPadding(0, 8, 0, 8)
+            }
+
+            grid.addView(label, GridLayout.LayoutParams().apply {
+                width = 0
+                height = GridLayout.LayoutParams.WRAP_CONTENT
+                columnSpec = GridLayout.spec(i, 1f)
+                rowSpec = GridLayout.spec(0)
+            })
+        }
+
+        repeat(42) { index ->
+            val day = gridStart.plusDays(index)
+            val isCurrentMonth = isSameMonth(day, currentMonth)
+            val isSelected = day.millis == selectedMonthDay.millis
+            val events = dayEvents(day)
+
+            val cell = LinearLayout(requireContext()).apply {
+                orientation = LinearLayout.VERTICAL
+                gravity = Gravity.TOP
+                setPadding(6, 6, 6, 6)
+                alpha = if (isCurrentMonth) 1f else 0.6f
+
+                if (isSelected) {
+                    setBackgroundResource(com.google.android.material.R.drawable.m3_tabs_rounded_line_indicator)
+                }
+
+                isClickable = true
+                isFocusable = true
+                setOnClickListener {
+                    selectedMonthDay = day
+                    renderMonthView()
+                }
+            }
+
+            val dayNumber = TextView(requireContext()).apply {
+                text = day.dayOfMonth.toString()
+                gravity = Gravity.CENTER
+                textAlignment = View.TEXT_ALIGNMENT_CENTER
+            }
+
+            cell.addView(dayNumber)
+
+            val (allDay, timed) = splitEvents(events)
+
+            allDay.take(2).forEach {
+                cell.addView(buildEventView(it, textSize, showBookName, false))
+            }
+
+            timed.take(2).forEach {
+                val hour = hourForEvent(it.agendaItem) ?: 0
+                cell.addView(buildEventView(it, textSize, showBookName, true, hour))
+            }
+
+            if (events.size > 4) {
+                cell.addView(TextView(requireContext()).apply {
+                    text = "•"
+                    gravity = Gravity.CENTER
+                    alpha = 0.7f
+                })
+            }
+
+            grid.addView(cell, GridLayout.LayoutParams().apply {
+                width = 0
+                height = 0
+                columnSpec = GridLayout.spec(index % 7, 1f)
+                rowSpec = GridLayout.spec(index / 7 + 1, 1f)
+            })
+        }
+    }
+
+    // Week view
+    private fun renderWeekView() {
+        binding.monthGrid.visibility = View.GONE
+        binding.monthDayEventsRecyclerView.visibility = View.GONE
+        binding.weekColumnsContainer.visibility = View.VISIBLE
+        binding.monthLabel.text = weekLabel(currentWeekStart)
+
+        val container = binding.weekColumnsContainer
+        container.removeAllViews()
+
+        val textSize = AppPreferences.calendarTextSize(requireContext()).toFloat()
+        val showBookName = AppPreferences.calendarShowBookName(requireContext())
+
+        val today = DateTime.now().withTimeAtStartOfDay()
+
+        val dayLabels = java.text.DateFormatSymbols(Locale.getDefault()).shortWeekdays
+
+        repeat(7) { offset ->
+            val day = currentWeekStart.plusDays(offset)
+
+            val isToday = day.millis == today.millis
+
+            val cal = java.util.Calendar.getInstance().apply {
+                timeInMillis = day.millis
+            }
+
+            val column = LinearLayout(requireContext()).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(10, 6, 10, 6)
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f)
+                gravity = Gravity.TOP
+            }
+
+            val header = TextView(requireContext()).apply {
+                text = "${dayLabels[cal.get(java.util.Calendar.DAY_OF_WEEK)]} \n" +
+                        "${cal.get(java.util.Calendar.DAY_OF_MONTH)}/${cal.get(java.util.Calendar.MONTH) + 1}"
+                setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_TitleSmall)
+
+                if (isToday) {
+                    setTypeface(typeface, android.graphics.Typeface.BOLD)
+                    alpha = 1f
+                } else {
+                    alpha = 0.6f
+                }
+            }
+
+            column.addView(header)
+
+            val events = dayEvents(day)
+
+            if (events.isEmpty()) {
+                column.addView(simpleEmptyView())
+            } else {
+                val (allDay, timed) = splitEvents(events)
+
+                allDay.forEach {
+                    column.addView(buildEventView(it, textSize, showBookName, false))
+                }
+
+                timed.sortedBy { hourForEvent(it.agendaItem) ?: 0 }.forEach {
+                    val hour = hourForEvent(it.agendaItem) ?: 0
+                    column.addView(buildEventView(it, textSize, showBookName, true, hour))
+                }
+            }
+
+            container.addView(column)
+        }
+        updateTodayButtonState()
+    }
+    
+    // Event view
+    private fun buildEventView(
+        e: DayEvent,
+        textSize: Float,
+        showBookName: Boolean,
+        showTime: Boolean,
+        hour: Int = 0
+    ): View {
+
+        val container = LinearLayout(requireContext()).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(0, 3, 0, 3)
+            gravity = Gravity.TOP
+        }
+
+        val title = TextView(requireContext()).apply {
+            text = createEventText(e, showBookName)
+            this.textSize = textSize * 0.9f
+            maxLines = 2
+            ellipsize = android.text.TextUtils.TruncateAt.END
+        }
+
+        container.addView(title)
+
+        if (showTime) {
+            container.addView(TextView(requireContext()).apply {
+                text = String.format("%02d:00", hour)
+                this.textSize = textSize * 0.7f   // 👈 MÁS PEQUEÑO
+                alpha = 0.6f
+            })
+        }
+
+        container.isClickable = true
+        container.setOnClickListener { openNote(e.agendaItem) }
+        container.setOnLongClickListener {
+            toggleNoteSelectionFromItem(e.agendaItem)
+            true
+        }
+
+        return container
+    }
+
+    // Helpers    
+    private fun splitEvents(events: List<DayEvent>): Pair<List<DayEvent>, List<DayEvent>> {
+        return events.partition { hourForEvent(it.agendaItem) == null }
+    }
+
+    private fun createEventText(
+        e: DayEvent,
+        showBookName: Boolean
+    ): String {
+        val base = if (showBookName)
+            "${e.title} (${e.bookName})"
+        else e.title
+
+        return base
+    }
+
+    private fun simpleEmptyView(): View {
+        return TextView(requireContext()).apply {
+            text = "-"
+            alpha = 0.5f
+        }
+    }
+
+    private fun recomputeMonthItems(notes: List<NoteView>) {
+        monthItem2databaseIds.clear()
+        calendarItemsByDay.clear()
+        var monthItemId = 1L
+
+        notes.forEach { note ->
+            addCalendarItem(note, note.scheduledTimeTimestamp, TimeType.SCHEDULED, monthItemId)?.let {
+                monthItemId = it
+            }
+            addCalendarItem(note, note.deadlineTimeTimestamp, TimeType.DEADLINE, monthItemId)?.let {
+                monthItemId = it
+            }
+            addCalendarItem(note, note.eventTimestamp, TimeType.EVENT, monthItemId)?.let {
+                monthItemId = it
+            }
+        }
+
+        calendarItemsByDay.values.forEach { dayItems ->
+            dayItems.sortWith { a, b -> AgendaItem.Note.compareByTimeInDay(a, b) }
+        }
+
+        calendarItemsByDay = linkedMapOf<Long, MutableList<AgendaItem.Note>>().also { sorted ->
+            calendarItemsByDay.keys.sorted().forEach { key ->
+                sorted[key] = calendarItemsByDay.getValue(key)
+            }
+        }
+    }
+
+    private fun addCalendarItem(
+        note: NoteView,
+        timestamp: Long?,
+        timeType: TimeType,
+        nextId: Long
+    ): Long? {
+        val startOfDay = timestamp?.let { DateTime(it).withTimeAtStartOfDay().millis } ?: return null
+        val item = AgendaItem.Note(nextId, note, timeType)
+        calendarItemsByDay.getOrPut(startOfDay) { mutableListOf() }.add(item)
+        monthItem2databaseIds[nextId] = note.note.id
+        return nextId + 1
+    }
+
+    private fun updateTodayButtonState() {
+        val today = DateTime.now().withTimeAtStartOfDay()
+
+        val isToday =
+            selectedMonthDay.millis == today.millis &&
+            currentWeekStart == weekStartFor(today)
+
+        binding.viewModeTodayButton.backgroundTintList =
+            if (isToday) null
+            else android.content.res.ColorStateList.valueOf(0xFFE0E0E0.toInt())
+    }
+
+    private fun goToToday() {
+        val today = DateTime.now().withTimeAtStartOfDay()
+        selectedMonthDay = today
+        currentMonth = today.withDayOfMonth(1)
+        currentWeekStart = weekStartFor(today)
+        updateDisplayMode()
+        updateTodayButtonState()
+    }
+
+    private fun weekLabel(weekStart: DateTime): String {
+        val weekEnd = weekStart.plusDays(6)
+        val start = DateUtils.formatDateTime(context, weekStart.millis, DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_ABBREV_MONTH)
+        val end = DateUtils.formatDateTime(context, weekEnd.millis, DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_ABBREV_MONTH)
+        return "$start - $end"
+    }
+
+    private fun dayEvents(day: DateTime): List<DayEvent> {
+        return calendarItemsByDay[day.millis].orEmpty().map { noteItem ->
+            DayEvent(
+                noteId = noteItem.note.note.id,
+                title = noteItem.note.note.title,
+                bookName = noteItem.note.bookName,
+                timeLabel = formatEventTime(noteItem),
+                agendaItem = noteItem
+            )
+        }
+    }
+
+    private fun hourForEvent(item: AgendaItem.Note): Int? {
+        return when (item.timeType) {
+            TimeType.SCHEDULED -> item.note.scheduledTimeHour
+            TimeType.DEADLINE -> item.note.deadlineTimeHour
+            TimeType.EVENT -> item.note.eventHour
+            else -> null
+        }
+    }
+
+    private fun firstDayOfWeek(): Int {
+        return if (AppPreferences.calendarFirstDayOfWeek(requireContext()) == "sunday") {
+            DateTimeConstants.SUNDAY
+        } else {
+            DateTimeConstants.MONDAY
+        }
+    }
+
+    private fun weekStartFor(day: DateTime): DateTime {
+        val first = firstDayOfWeek()
+        val diff = (7 + day.dayOfWeek - first) % 7
+        return day.minusDays(diff).withTimeAtStartOfDay()
+    }
+
+    private fun toggleNoteSelectionFromItem(item: AgendaItem.Note) {
+        val adapter = getActiveAdapter()
+        adapter.getSelection().toggle(item.id)
+        viewModel.appBar.toModeFromSelectionCount(adapter.getSelection().count)
+    }
+
+    private fun updateModeButtons() {
+        binding.viewModeAgendaButton.isEnabled = displayMode != DisplayMode.AGENDA
+        binding.viewModeWeekButton.isEnabled = displayMode != DisplayMode.WEEK
+        binding.viewModeMonthButton.isEnabled = displayMode != DisplayMode.MONTH
+    }
+
+    private fun formatEventTime(item: AgendaItem.Note): String? {
+        val timestamp = when (item.timeType) {
+            TimeType.SCHEDULED -> item.note.scheduledTimeTimestamp
+            TimeType.DEADLINE -> item.note.deadlineTimeTimestamp
+            TimeType.EVENT -> item.note.eventTimestamp
+            else -> null
+        } ?: return null
+
+        val hasHour = when (item.timeType) {
+            TimeType.SCHEDULED -> item.note.scheduledTimeHour != null
+            TimeType.DEADLINE -> item.note.deadlineTimeHour != null
+            TimeType.EVENT -> item.note.eventHour != null
+            else -> false
+        }
+
+        return if (hasHour) {
+            DateUtils.formatDateTime(context, timestamp, DateUtils.FORMAT_SHOW_TIME)
+        } else {
+            null
+        }
+    }
+
+    private fun isSameMonth(day: DateTime, month: DateTime): Boolean {
+        return day.year == month.year && day.monthOfYear == month.monthOfYear
     }
 
     companion object {
@@ -330,6 +867,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
             val args = Bundle()
             args.putString(ARG_QUERY, query)
+            args.putBoolean(ARG_CALENDAR_MODE, false)
             if (queryName != null) {
                 args.putString(ARG_QUERY_NAME, queryName)
             }
@@ -337,6 +875,24 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
             return fragment
         }
+
+        @JvmStatic
+        fun getCalendarInstance(): AgendaFragment {
+            val fragment = AgendaFragment()
+            val args = Bundle()
+            args.putString(ARG_QUERY, "ad.365")
+            args.putString(ARG_QUERY_NAME, null)
+            args.putBoolean(ARG_CALENDAR_MODE, true)
+            fragment.arguments = args
+            return fragment
+        }
+
+        @JvmStatic
+        fun getCalendarDrawerItemId(): String {
+            return "$FRAGMENT_TAG calendar"
+        }
+
+        private const val ARG_CALENDAR_MODE = "calendar_mode"
     }
 
 }

--- a/app/src/main/res/layout/fragment_query_agenda.xml
+++ b/app/src/main/res/layout/fragment_query_agenda.xml
@@ -17,14 +17,149 @@
 
             <ProgressBar style="@style/LoadingProgressBar" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/fragment_query_agenda_recycler_view"
-                style="@style/FastScroll"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginTop="?attr/actionBarSize"
-                android:paddingBottom="?attr/actionBarSize"
-                android:clipToPadding="false" />
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/calendar_controls_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="8dp">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/view_mode_agenda_button"
+                        android:layout_width="0dp"
+                        android:layout_height="40dp"
+                        android:layout_weight="1"
+                        android:layout_marginEnd="4dp"
+                        android:text="@string/agenda"
+                        app:cornerRadius="4dp"
+                        android:insetLeft="2dp"
+                        android:insetRight="2dp" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/view_mode_week_button"
+                        android:layout_width="0dp"
+                        android:layout_height="40dp"
+                        android:layout_weight="1"
+                        android:layout_marginEnd="4dp"
+                        android:text="@string/week"
+                        app:cornerRadius="4dp"
+                        android:insetLeft="2dp"
+                        android:insetRight="2dp" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/view_mode_month_button"
+                        android:layout_width="0dp"
+                        android:layout_height="40dp"
+                        android:layout_weight="1"
+                        android:layout_marginEnd="4dp"
+                        android:text="@string/month"
+                        app:cornerRadius="4dp"
+                        android:insetLeft="2dp"
+                        android:insetRight="2dp" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/view_mode_today_button"
+                        android:layout_width="0dp"
+                        android:layout_height="40dp"
+                        android:layout_weight="0.4"
+                        app:icon="@drawable/ic_today"
+                        app:iconPadding="2dp"
+                        app:iconGravity="textStart"
+                        android:gravity="center"
+                        app:cornerRadius="4dp"
+                        android:insetLeft="4dp"
+                        android:insetRight="4dp" />
+
+                </LinearLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/fragment_query_agenda_recycler_view"
+                    style="@style/FastScroll"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:paddingBottom="?attr/actionBarSize"
+                    android:clipToPadding="false" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/fragment_query_agenda_month_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="?attr/actionBarSize"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="16dp"
+                    android:paddingTop="12dp"
+                    android:paddingEnd="16dp"
+                    android:paddingBottom="8dp">
+
+                    <ImageButton
+                        android:id="@+id/month_prev_button"
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/previous_month"
+                        android:src="@drawable/ic_arrow_back" />
+
+                    <TextView
+                        android:id="@+id/month_label"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+                    <ImageButton
+                        android:id="@+id/month_next_button"
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/next_month"
+                        android:src="@drawable/ic_arrow_forward" />
+                </LinearLayout>
+
+                <GridLayout
+                    android:id="@+id/month_grid"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:columnCount="7"
+                    android:paddingStart="8dp"
+                    android:paddingEnd="8dp"
+                    android:paddingBottom="8dp" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/month_day_events_recycler_view"
+                    style="@style/FastScroll"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:paddingBottom="?attr/actionBarSize"
+                    android:clipToPadding="false"
+                    android:visibility="gone" />
+
+                <LinearLayout
+                    android:id="@+id/week_columns_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="horizontal"
+                    android:paddingStart="8dp"
+                    android:paddingEnd="8dp"
+                    android:paddingBottom="?attr/actionBarSize"
+                    android:visibility="gone" />
+            </LinearLayout>
 
         </ViewFlipper>
 

--- a/app/src/main/res/menu/drawer.xml
+++ b/app/src/main/res/menu/drawer.xml
@@ -17,12 +17,19 @@
             android:orderInCategory="2"/>
 
         <item
+            android:id="@+id/calendar"
+            android:icon="@drawable/ic_today"
+            android:title="@string/calendar"
+            android:checkable="true"
+            android:orderInCategory="4"/>
+
+        <item
             android:id="@+id/settings"
             android:icon="@drawable/ic_settings"
             android:title="@string/settings"
-            android:orderInCategory="4"/>
+            android:orderInCategory="6"/>
 
         <!-- FIXME: Space for sync button and progress bar -->
-        <item android:title="" android:enabled="false" android:orderInCategory="6" />
+        <item android:title="" android:enabled="false" android:orderInCategory="8" />
     </group>
 </menu>

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -356,6 +356,33 @@
     <string name="pref_key_group_scheduled_with_today" translatable="false">pref_key_group_scheduled_with_today</string>
     <bool name="pref_default_group_scheduled_with_today" translatable="false">true</bool>
 
+    <string name="pref_key_calendar_month_text_size" translatable="false">pref_key_calendar_month_text_size</string>
+    <string name="pref_default_calendar_month_text_size" translatable="false">14</string>
+    <string-array name="calendar_text_sizes">
+        <item>@string/font_size_small</item>
+        <item>@string/font_size_default</item>
+        <item>@string/font_size_large</item>
+    </string-array>
+    <string-array name="calendar_text_sizes_values">
+        <item>12</item>
+        <item>14</item>
+        <item>16</item>
+    </string-array>
+
+    <string name="pref_key_calendar_show_book_name" translatable="false">pref_key_calendar_show_book_name</string>
+    <bool name="pref_default_calendar_show_book_name" translatable="false">true</bool>
+
+    <string name="pref_key_calendar_first_day_of_week" translatable="false">pref_key_calendar_first_day_of_week</string>
+    <string name="pref_default_calendar_first_day_of_week" translatable="false">monday</string>
+    <string-array name="calendar_first_day_of_week_entries">
+        <item>@string/monday</item>
+        <item>@string/sunday</item>
+    </string-array>
+    <string-array name="calendar_first_day_of_week_values">
+        <item>monday</item>
+        <item>sunday</item>
+    </string-array>
+
     <string name="pref_key_selected_note_metadata" translatable="false">pref_key_selected_note_metadata</string>
     <string-array name="note_metadata">
         <item>@string/tags</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,7 +148,6 @@
 
     <string name="no_notes_found_after_search">Your search did not match any notes</string>
 
-    <string name="today">Today</string>
     <string name="tomorrow">Tomorrow</string>
     <string name="next_week">Next Week</string>
 
@@ -347,6 +346,19 @@
     <string name="day">Day</string>
     <string name="week">Week</string>
     <string name="month">Month</string>
+    <string name="month_view">Month view</string>
+    <string name="agenda_view">Agenda view</string>
+    <string name="week_view">Week view</string>
+    <string name="previous_month">Previous month</string>
+    <string name="next_month">Next month</string>
+    <string name="today">Today</string>
+    <string name="calendar_views">Calendar views</string>
+    <string name="calendar_text_size">Calendar text size</string>
+    <string name="calendar_show_book_name">Show notebook name in calendar</string>
+    <string name="calendar_first_day_of_week">First day of week</string>
+    <string name="monday">Monday</string>
+    <string name="sunday">Sunday</string>
+    <string name="calendar">Calendar</string>
     <string name="year">Year</string>
 
     <string name="repeater_dialog_title">Repeat</string>

--- a/app/src/main/res/xml/prefs_screen_look_and_feel.xml
+++ b/app/src/main/res/xml/prefs_screen_look_and_feel.xml
@@ -102,6 +102,27 @@
             android:title="@string/group_scheduled_with_today"
             android:summary="@string/group_scheduled_with_today_summary"
             android:defaultValue="@bool/pref_default_group_scheduled_with_today" />
+
+        <ListPreference
+            android:key="@string/pref_key_calendar_month_text_size"
+            android:title="@string/calendar_text_size"
+            android:entries="@array/calendar_text_sizes"
+            android:entryValues="@array/calendar_text_sizes_values"
+            android:defaultValue="@string/pref_default_calendar_month_text_size"
+            app:useSimpleSummaryProvider="true" />
+
+        <SwitchPreference
+            android:key="@string/pref_key_calendar_show_book_name"
+            android:title="@string/calendar_show_book_name"
+            android:defaultValue="@bool/pref_default_calendar_show_book_name" />
+
+        <ListPreference
+            android:key="@string/pref_key_calendar_first_day_of_week"
+            android:title="@string/calendar_first_day_of_week"
+            android:entries="@array/calendar_first_day_of_week_entries"
+            android:entryValues="@array/calendar_first_day_of_week_values"
+            android:defaultValue="@string/pref_default_calendar_first_day_of_week"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Add a new Calendar section in the navigation with week and month views.

Both views display events retrieved from a custom ad.365 query. The implementation focuses on presentation changes only.

Changes include:
- New navigation section with:
    - Agenda view (ad.365 default query)
    - Week view showing events grouped by day
    - Month view showing a calendar grid with events per day

**This was implemented with help from Cursor (AI-assisted coding), so I’m open to feedback, corrections, and improvements.**