### PR TITLE
(feat) Add month view to agenda queries

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -938,6 +938,18 @@ public class AppPreferences {
                 context.getResources().getBoolean(R.bool.pref_default_group_scheduled_with_today));
     }
 
+    public static int calendarTextSize(Context context) {
+        return Integer.parseInt(getDefaultSharedPreferences(context).getString(
+                context.getResources().getString(R.string.pref_key_calendar_month_text_size),
+                context.getResources().getString(R.string.pref_default_calendar_month_text_size)));
+    }
+
+    public static boolean calendarShowBookName(Context context) {
+        return getDefaultSharedPreferences(context).getBoolean(
+                context.getResources().getString(R.string.pref_key_calendar_show_book_name),
+                context.getResources().getBoolean(R.bool.pref_default_calendar_show_book_name));
+    }
+
     public static void groupScheduledWithTodayInAgenda(Context context, boolean value) {
         getDefaultSharedPreferences(context).edit().putBoolean(
                 context.getResources().getString(R.string.pref_key_group_scheduled_with_today),

--- a/app/src/main/java/com/orgzly/android/query/Options.kt
+++ b/app/src/main/java/com/orgzly/android/query/Options.kt
@@ -1,3 +1,3 @@
 package com.orgzly.android.query
 
-data class Options(val agendaDays: Int = 0)
+data class Options(val agendaDays: Int = 0, val agendaViewMode: String = "")

--- a/app/src/main/java/com/orgzly/android/query/user/BasicQueryParser.kt
+++ b/app/src/main/java/com/orgzly/android/query/user/BasicQueryParser.kt
@@ -103,9 +103,12 @@ open class BasicQueryParser : QueryParser() {
     )
 
     override val supportedOptions = listOf(
-            OptionMatch("""^agenda-days:(\d+)$""") { match, options ->
-                val days = match.groupValues[1].toInt()
-                if (days > 0) options.copy(agendaDays = days) else null
-            }
+        OptionMatch("""^agenda-days:(\d+)(?::(month))?$""") { match, options ->
+            val days = match.groupValues[1].toInt()
+            if (days > 0) options.copy(
+                agendaDays = days,
+                agendaViewMode = match.groupValues[2]
+            ) else null
+        }
     )
 }

--- a/app/src/main/java/com/orgzly/android/query/user/DottedQueryParser.kt
+++ b/app/src/main/java/com/orgzly/android/query/user/DottedQueryParser.kt
@@ -111,9 +111,12 @@ open class DottedQueryParser : QueryParser() {
     )
 
     override val supportedOptions = listOf(
-            OptionMatch("""^ad\.(\d+)$""") { match, options ->
-                val days = match.groupValues[1].toInt()
-                if (days > 0) options.copy(agendaDays = days) else null
-            }
+        OptionMatch("""^ad\.(\d+)(?::(month))?$""") { match, options ->
+            val days = match.groupValues[1].toInt()
+            if (days > 0) options.copy(
+                agendaDays = days,
+                agendaViewMode = match.groupValues[2]
+            ) else null
+        }
     )
 }

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaCalendarHelper.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaCalendarHelper.kt
@@ -1,0 +1,113 @@
+package com.orgzly.android.ui.notes.query.agenda
+
+import android.content.Context
+import android.text.format.DateUtils
+import com.orgzly.android.ui.TimeType
+import org.joda.time.DateTime
+import java.util.Calendar
+
+enum class CalendarDisplayMode { AGENDA, MONTH }
+
+enum class CalendarEventStyle { PLAIN, ACCENT_BAR, ACCENT_BAR_FULL }
+
+data class DayEvent(
+    val noteId: Long,
+    val title: String,
+    val bookName: String,
+    val timeLabel: String?,
+    val agendaItem: AgendaItem.Note
+)
+
+fun extractDisplayModeFromQuery(query: String): CalendarDisplayMode {
+    val match = Regex("""ad\.\d+:month""").find(query)
+    return if (match != null) CalendarDisplayMode.MONTH else CalendarDisplayMode.AGENDA
+}
+
+fun isSameMonth(day: DateTime, month: DateTime): Boolean =
+    day.year == month.year && day.monthOfYear == month.monthOfYear
+
+fun hourForEvent(item: AgendaItem.Note): Float? {
+    val (hour, timestamp) = when (item.timeType) {
+        TimeType.SCHEDULED -> Pair(item.note.scheduledTimeHour, item.note.scheduledTimeTimestamp)
+        TimeType.DEADLINE  -> Pair(item.note.deadlineTimeHour, item.note.deadlineTimeTimestamp)
+        TimeType.EVENT     -> Pair(item.note.eventHour, item.note.eventTimestamp)
+        else               -> Pair(null, null)
+    }
+    hour ?: return null
+    val minute = timestamp?.let {
+        Calendar.getInstance().apply { timeInMillis = it }.get(Calendar.MINUTE)
+    } ?: 0
+    return hour + minute / 60f
+}
+
+fun durationHoursForEvent(item: AgendaItem.Note): Float? {
+    val startFloat = hourForEvent(item) ?: return null
+    val orgString = when (item.timeType) {
+        TimeType.SCHEDULED -> item.note.scheduledTimeString
+        TimeType.DEADLINE  -> item.note.deadlineTimeString
+        TimeType.EVENT     -> item.note.eventEndTimestamp?.let {
+            val dt = DateTime(it)
+            return ((dt.hourOfDay + dt.minuteOfHour / 60f) - startFloat).coerceAtLeast(0.25f)
+        }
+        else -> null
+    } ?: return null
+    val match = Regex("""(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})""").find(orgString) ?: return null
+    val endFloat = (match.groupValues[3].toIntOrNull() ?: return null) +
+        (match.groupValues[4].toIntOrNull() ?: return null) / 60f
+    val duration = endFloat - startFloat
+    return if (duration > 0) duration.coerceAtLeast(0.25f) else null
+}
+
+fun isRepeating(item: AgendaItem.Note): Boolean {
+    val str = when (item.timeType) {
+        TimeType.SCHEDULED -> item.note.scheduledTimeString
+        TimeType.DEADLINE  -> item.note.deadlineTimeString
+        TimeType.EVENT     -> item.note.eventString
+        else -> null
+    } ?: return false
+    return str.contains(Regex("""[.+]?\+\d+[hdwmy]"""))
+}
+
+fun formatEventTime(context: Context, item: AgendaItem.Note): String? {
+    val timestamp = when (item.timeType) {
+        TimeType.SCHEDULED -> item.note.scheduledTimeTimestamp
+        TimeType.DEADLINE  -> item.note.deadlineTimeTimestamp
+        TimeType.EVENT     -> item.note.eventTimestamp
+        else               -> null
+    } ?: return null
+    val hasHour = when (item.timeType) {
+        TimeType.SCHEDULED -> item.note.scheduledTimeHour != null
+        TimeType.DEADLINE  -> item.note.deadlineTimeHour != null
+        TimeType.EVENT     -> item.note.eventHour != null
+        else               -> false
+    }
+    return if (hasHour) DateUtils.formatDateTime(context, timestamp, DateUtils.FORMAT_SHOW_TIME) else null
+}
+
+fun eventsForDay(items: List<AgendaItem>, day: DateTime): List<AgendaItem.Note> {
+    val targetMillis = day.withTimeAtStartOfDay().millis
+    val result = mutableListOf<AgendaItem.Note>()
+    var inTargetDay = false
+    for (item in items) {
+        when (item) {
+            is AgendaItem.Day     -> inTargetDay = item.day.withTimeAtStartOfDay().millis == targetMillis
+            is AgendaItem.Note    -> if (inTargetDay) result.add(item)
+            is AgendaItem.Overdue -> {}
+        }
+    }
+    return result
+}
+
+fun dayEvents(context: Context, items: List<AgendaItem>, day: DateTime): List<DayEvent> =
+    eventsForDay(items, day).map { noteItem ->
+        DayEvent(
+            noteId     = noteItem.note.note.id,
+            title      = noteItem.note.note.title,
+            bookName   = noteItem.note.bookName,
+            timeLabel  = formatEventTime(context, noteItem),
+            agendaItem = noteItem
+        )
+    }
+
+fun splitEvents(events: List<DayEvent>): Pair<List<DayEvent>, List<DayEvent>> =
+    events.partition { hourForEvent(it.agendaItem) == null }

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
@@ -3,10 +3,15 @@ package com.orgzly.android.ui.notes.query.agenda
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.getValue
@@ -45,6 +50,7 @@ import com.orgzly.android.ui.util.setup
 import com.orgzly.android.util.LogUtils
 import com.orgzly.databinding.FragmentQueryAgendaBinding
 import kotlin.getValue
+import org.joda.time.DateTime
 
 
 /**
@@ -57,7 +63,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
     lateinit var viewAdapter: AgendaAdapter
 
-    override val viewModel: QueryViewModel  by viewModels {
+    override val viewModel: QueryViewModel by viewModels {
         QueryViewModelFactory.provideFactory(
             viewModelFactory,
             requireArguments().getString(ARG_QUERY) ?: "",
@@ -66,6 +72,14 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
             requireContext()
         )
     }
+
+    private var displayMode: CalendarDisplayMode = CalendarDisplayMode.AGENDA
+    private var currentMonth: DateTime = DateTime.now().withTimeAtStartOfDay().withDayOfMonth(1)
+    private var selectedMonthDay: DateTime = DateTime.now().withTimeAtStartOfDay()
+    private var currentItems: List<AgendaItem> = emptyList()
+    private var internalTodayButton: ImageButton? = null
+
+    private lateinit var monthView: AgendaMonthView
 
     private val appBarBackPressHandler = object : OnBackPressedCallback(false) {
         override fun handleOnBackPressed() {
@@ -82,6 +96,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
         requireActivity().onBackPressedDispatcher.addCallback(this, appBarBackPressHandler)
         requireActivity().onBackPressedDispatcher.addCallback(this, notePopupDismissOnBackPress)
+        displayMode = extractDisplayModeFromQuery(arguments?.getString(ARG_QUERY) ?: "")
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -117,8 +132,22 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
         // Restores selection, requires adapter
         super.onViewCreated(view, savedInstanceState)
 
+        monthView = AgendaMonthView(
+            fragment          = this,
+            binding           = binding,
+            getItems          = { currentItems },
+            getCurrentMonth   = { currentMonth },
+            getSelectedDay    = { selectedMonthDay },
+            onDaySelected     = { day -> selectedMonthDay = day; renderMonthView() },
+            openNote          = { openNote(it) },
+            onSelectionToggle = { item ->
+                viewAdapter.getSelection().toggle(item.id)
+                viewModel.appBar.toModeFromSelectionCount(viewAdapter.getSelection().count)
+            }
+        )
+
         val layoutManager = StickyHeadersLinearLayoutManager<AgendaAdapter>(
-                context, LinearLayoutManager.VERTICAL, false)
+            context, LinearLayoutManager.VERTICAL, false)
 
         val dividerItemDecoration = DividerItemDecoration(context, layoutManager.orientation)
 
@@ -143,6 +172,11 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
                 }
             }))
         }
+
+        binding.fragmentQueryAgendaRecyclerView.visibility = View.GONE
+        binding.fragmentQueryAgendaMonthContainer.visibility = View.GONE
+        setupCalendarControls()
+        updateDisplayMode()
 
         binding.swipeContainer.setup()
 
@@ -297,7 +331,12 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
             if (BuildConfig.LOG_DEBUG)
                 LogUtils.d(TAG, "Replacing data with ${list.items.size} agenda items")
 
+            currentItems = list.items
             viewAdapter.submitList(list.items)
+
+            if (::binding.isInitialized && displayMode == CalendarDisplayMode.MONTH) {
+                renderMonthView()
+            }
 
             val ids = notes.mapTo(hashSetOf()) { it.note.id }
 
@@ -313,6 +352,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
                 APP_BAR_DEFAULT_MODE -> {
                     topToolbarToDefault()
                     bottomToolbarToDefault()
+                    updateDisplayMode()
 
                     sharedMainActivityViewModel.unlockDrawer()
 
@@ -366,6 +406,69 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
             viewModel.appBar.toModeFromSelectionCount(viewAdapter.getSelection().count)
         }
+    }
+
+    private fun setupCalendarControls() {
+        binding.monthPrevButton.setOnClickListener {
+            if (displayMode == CalendarDisplayMode.MONTH) {
+                currentMonth = currentMonth.minusMonths(1)
+                if (!isSameMonth(selectedMonthDay, currentMonth)) selectedMonthDay = currentMonth
+                renderMonthView()
+            }
+        }
+        binding.monthNextButton.setOnClickListener {
+            if (displayMode == CalendarDisplayMode.MONTH) {
+                currentMonth = currentMonth.plusMonths(1)
+                if (!isSameMonth(selectedMonthDay, currentMonth)) selectedMonthDay = currentMonth
+                renderMonthView()
+            }
+        }
+    }
+
+    private fun updateDisplayMode() {
+        if (!::binding.isInitialized) return
+        binding.fragmentQueryAgendaMonthContainer.setPadding(0, 0, 0, 0)
+        binding.fragmentQueryAgendaRecyclerView.itemAnimator = null
+        binding.fragmentQueryAgendaRecyclerView.visibility =
+            if (displayMode == CalendarDisplayMode.AGENDA) View.VISIBLE else View.GONE
+        binding.fragmentQueryAgendaMonthContainer.visibility =
+            if (displayMode == CalendarDisplayMode.AGENDA) View.GONE else View.VISIBLE
+    }
+
+    private fun buildTodayButton(goToToday: () -> Unit): ImageButton {
+        val dp36 = (36 * resources.displayMetrics.density).toInt()
+        return ImageButton(requireContext()).apply {
+            setImageResource(R.drawable.ic_today)
+            setBackgroundColor(Color.TRANSPARENT)
+            setPadding(12, 6, 12, 6)
+            scaleType = ImageView.ScaleType.CENTER_INSIDE
+            layoutParams = LinearLayout.LayoutParams(dp36, WRAP_CONTENT)
+            setOnClickListener { goToToday() }
+        }
+    }
+
+    private fun attachTodayButton(container: LinearLayout, goToToday: () -> Unit) {
+        internalTodayButton = buildTodayButton(goToToday)
+        container.addView(internalTodayButton)
+        updateTodayButtonState()
+    }
+
+    private fun updateTodayButtonState() {
+        val today = DateTime.now().withTimeAtStartOfDay()
+        val isAtToday = displayMode == CalendarDisplayMode.MONTH &&
+            currentMonth == today.withDayOfMonth(1)
+        internalTodayButton?.setColorFilter(if (isAtToday) Color.GRAY else Color.WHITE)
+    }
+
+    private fun goToToday() {
+        val today = DateTime.now().withTimeAtStartOfDay()
+        selectedMonthDay = today
+        currentMonth = today.withDayOfMonth(1)
+        renderMonthView()
+    }
+
+    private fun renderMonthView() {
+        monthView.render(currentMonth, selectedMonthDay, ::attachTodayButton, ::goToToday)
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaMonthView.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaMonthView.kt
@@ -1,0 +1,215 @@
+package com.orgzly.android.ui.notes.query.agenda
+
+import android.graphics.Color
+import android.text.format.DateUtils
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.GridLayout
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.orgzly.R
+import com.orgzly.android.prefs.AppPreferences
+import com.orgzly.databinding.FragmentQueryAgendaBinding
+import org.joda.time.DateTime
+import org.joda.time.DateTimeConstants
+import java.text.DateFormatSymbols
+import java.util.Calendar
+import java.util.Locale
+
+class AgendaMonthView(
+    private val fragment: Fragment,
+    private val binding: FragmentQueryAgendaBinding,
+    private val getItems: () -> List<AgendaItem>,
+    private val getCurrentMonth: () -> DateTime,
+    private val getSelectedDay: () -> DateTime,
+    private val onDaySelected: (DateTime) -> Unit,
+    private val openNote: (AgendaItem) -> Unit,
+    private val onSelectionToggle: (AgendaItem.Note) -> Unit
+) {
+    private fun themeColor(attr: Int): Int {
+        val tv = TypedValue()
+        fragment.requireContext().theme.resolveAttribute(attr, tv, true)
+        return tv.data
+    }
+
+    fun render(month: DateTime, selectedDay: DateTime, attachTodayButtonFn: (LinearLayout, () -> Unit) -> Unit, goToToday: () -> Unit) {
+        binding.monthGrid.visibility = View.VISIBLE
+        binding.monthDayEventsRecyclerView.visibility = View.GONE
+
+        binding.monthLabelContainer.removeAllViews()
+        binding.monthLabelContainer.addView(binding.monthLabel)
+        binding.monthLabel.text = DateUtils.formatDateTime(
+            fragment.requireContext(), month.millis,
+            DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_NO_MONTH_DAY
+        )
+        attachTodayButtonFn(binding.monthLabelContainer, goToToday)
+        renderGrid(month, selectedDay)
+    }
+
+    private fun renderGrid(month: DateTime, selectedDay: DateTime) {
+        val grid = binding.monthGrid
+        grid.removeAllViews()
+        val ctx            = fragment.requireContext()
+        val textSize       = AppPreferences.calendarTextSize(ctx).toFloat()
+        val showBook       = AppPreferences.calendarShowBookName(ctx)
+        val systemFirstDOW = Calendar.getInstance().firstDayOfWeek
+        val firstDOWJoda   = if (systemFirstDOW == Calendar.SUNDAY) DateTimeConstants.SUNDAY else DateTimeConstants.MONDAY
+        val firstDay       = month.withDayOfMonth(1).withTimeAtStartOfDay()
+        val gridStart      = firstDay.minusDays((7 + firstDay.dayOfWeek - firstDOWJoda) % 7)
+        val dayLabels      = DateFormatSymbols(Locale.getDefault()).shortWeekdays
+        val density        = fragment.resources.displayMetrics.density
+
+        val colorOnSurface = themeColor(com.google.android.material.R.attr.colorOnSurface)
+        val selectedBg     = (colorOnSurface and 0x00FFFFFF) or 0x44000000
+        val barColor       = themeColor(com.google.android.material.R.attr.colorSecondary)
+
+        repeat(7) { i ->
+            grid.addView(
+                TextView(ctx).apply {
+                    text = dayLabels[(systemFirstDOW + i - 1) % 7 + 1]
+                    gravity = Gravity.CENTER
+                    setPadding(0, 8, 0, 8)
+                },
+                GridLayout.LayoutParams().apply {
+                    width = 0; height = GridLayout.LayoutParams.WRAP_CONTENT
+                    columnSpec = GridLayout.spec(i, 1f)
+                    rowSpec    = GridLayout.spec(0)
+                }
+            )
+        }
+
+        repeat(42) { index ->
+            val day        = gridStart.plusDays(index)
+            val inMonth    = isSameMonth(day, month)
+            val isSelected = day.millis == selectedDay.millis
+            val events     = dayEvents(ctx, getItems(), day)
+            val (allDay, timed) = splitEvents(events)
+
+            val cell = LinearLayout(ctx).apply {
+                orientation = LinearLayout.VERTICAL
+                gravity     = Gravity.TOP
+                setPadding(6, 6, 6, 6)
+                alpha = if (inMonth) 1f else 0.4f
+                if (isSelected) {
+                    background = android.graphics.drawable.GradientDrawable().apply {
+                        setColor(selectedBg)
+                        cornerRadius = 12f
+                    }
+                }
+                isClickable = true
+                isFocusable = true
+                setOnClickListener { onDaySelected(day) }
+            }
+
+            cell.addView(TextView(ctx).apply {
+                text = day.dayOfMonth.toString()
+                gravity = Gravity.CENTER
+                textAlignment = View.TEXT_ALIGNMENT_CENTER
+            })
+
+            allDay.take(2).forEach { cell.addView(buildEventView(it, textSize, showBook, false, density = density, barColor = barColor, colorOnSurface = colorOnSurface)) }
+            timed.take(2).forEach {
+                cell.addView(buildEventView(it, textSize, showBook, true,
+                    hourForEvent(it.agendaItem) ?: 0f,
+                    if (!isRepeating(it.agendaItem)) CalendarEventStyle.ACCENT_BAR else CalendarEventStyle.PLAIN,
+                    density = density, barColor = barColor, colorOnSurface = colorOnSurface))
+            }
+            if (events.size > 4) {
+                cell.addView(TextView(ctx).apply { text = "•"; gravity = Gravity.CENTER; alpha = 0.7f })
+            }
+
+            grid.addView(cell, GridLayout.LayoutParams().apply {
+                width = 0; height = 0
+                columnSpec = GridLayout.spec(index % 7, 1f)
+                rowSpec    = GridLayout.spec(index / 7 + 1, 1f)
+            })
+        }
+    }
+
+    private fun buildEventView(
+        e: DayEvent,
+        textSize: Float,
+        showBookName: Boolean = false,
+        showTime: Boolean = false,
+        hour: Float = 0f,
+        style: CalendarEventStyle = CalendarEventStyle.PLAIN,
+        density: Float = 1f,
+        barColor: Int = Color.GRAY,
+        colorOnSurface: Int = Color.BLACK
+    ): View {
+        val ctx         = fragment.requireContext()
+        val showBar     = style != CalendarEventStyle.PLAIN
+        val matchHeight = style == CalendarEventStyle.ACCENT_BAR_FULL
+
+        val bgAlpha    = if (showBar) 0x18 else 0x33
+        val eventBgArgb = (colorOnSurface and 0x00FFFFFF) or (bgAlpha shl 24)
+
+        val content = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(4, 3, 4, 3)
+            gravity = Gravity.TOP
+            background = android.graphics.drawable.GradientDrawable().apply {
+                setColor(eventBgArgb)
+                cornerRadius = 2 * density
+            }
+            addView(TextView(ctx).apply {
+                text = e.title
+                this.textSize = textSize * 0.9f
+                maxLines = 2
+                ellipsize = android.text.TextUtils.TruncateAt.END
+            })
+            if (showBookName) {
+                addView(TextView(ctx).apply {
+                    text = e.bookName
+                    this.textSize = textSize * 0.7f
+                    maxLines = 1
+                    ellipsize = android.text.TextUtils.TruncateAt.END
+                    alpha = 0.8f
+                })
+            }
+            if (showTime) {
+                val h = hour.toInt()
+                val m = ((hour % 1) * 60).toInt()
+                val startStr = String.format("%02d:%02d", h, m)
+                val duration = durationHoursForEvent(e.agendaItem)
+                val timeStr = if (duration != null) {
+                    val endFloat = hour + duration
+                    "$startStr-${String.format("%02d:%02d", endFloat.toInt(), ((endFloat % 1) * 60).toInt())}"
+                } else startStr
+                addView(TextView(ctx).apply {
+                    text = timeStr
+                    this.textSize = textSize * 0.7f
+                    alpha = 0.6f
+                })
+            }
+            isClickable = true
+            setOnClickListener { openNote(e.agendaItem) }
+            setOnLongClickListener { onSelectionToggle(e.agendaItem); true }
+        }
+
+        return if (showBar) {
+            LinearLayout(ctx).apply {
+                orientation = LinearLayout.HORIZONTAL
+                layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT).apply { setMargins(2, 2, 2, 2) }
+                addView(View(ctx).apply {
+                    layoutParams = LinearLayout.LayoutParams(4, MATCH_PARENT).apply { setMargins(0, 2, 4, 2) }
+                    background = android.graphics.drawable.GradientDrawable().apply {
+                        setColor(barColor)
+                        cornerRadius = 8f
+                    }
+                })
+                addView(content, LinearLayout.LayoutParams(0, if (matchHeight) MATCH_PARENT else WRAP_CONTENT, 1f))
+            }
+        } else {
+            content.apply {
+                layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT).apply { setMargins(0, 0, 0, 4) }
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_query_agenda.xml
+++ b/app/src/main/res/layout/fragment_query_agenda.xml
@@ -17,38 +17,118 @@
 
             <ProgressBar style="@style/LoadingProgressBar" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/fragment_query_agenda_recycler_view"
-                style="@style/FastScroll"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginTop="?attr/actionBarSize"
+                android:orientation="vertical"
                 android:paddingBottom="@dimen/fragment_query_bottom_padding"
-                android:clipToPadding="false" />
+                android:clipToPadding="false">
 
-        </ViewFlipper>
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/fragment_query_agenda_recycler_view"
+                    style="@style/FastScroll"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
+                    android:paddingBottom="?attr/actionBarSize"
+                    android:clipToPadding="false" />
 
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+                <LinearLayout
+                    android:id="@+id/fragment_query_agenda_month_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="?attr/actionBarSize"
+                    android:orientation="vertical"
+                    android:visibility="gone">
 
-    <!-- Top toolbar -->
-    <!-- TODO: DRY -->
-    <com.google.android.material.appbar.AppBarLayout
-        style="@style/AppBarLayoutStyle">
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:paddingStart="16dp"
+                        android:paddingTop="12dp"
+                        android:paddingEnd="16dp"
+                        android:paddingBottom="8dp">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/top_toolbar"
-            style="@style/TopToolbar"
-            app:navigationIcon="@drawable/ic_menu" />
+                        <ImageButton
+                            android:id="@+id/month_prev_button"
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:contentDescription="@string/previous_month"
+                            android:src="@drawable/ic_arrow_back" />
 
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/sync_toolbar_progress"
-            style="@style/SyncProgressIndicator" />
+                        <LinearLayout
+                            android:id="@+id/month_label_container"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="horizontal"
+                            android:gravity="center_vertical">
 
-    </com.google.android.material.appbar.AppBarLayout>
+                            <TextView
+                                android:id="@+id/month_label"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:gravity="center"
+                                android:textAppearance="?attr/textAppearanceTitleMedium" />
+                            </LinearLayout>
 
-    <!-- Bottom toolbar -->
-    <com.google.android.material.bottomappbar.BottomAppBar
-        android:id="@+id/bottom_toolbar"
-        style="@style/BottomToolbar" />
+                            <ImageButton
+                                android:id="@+id/month_next_button"
+                                android:layout_width="40dp"
+                                android:layout_height="40dp"
+                                android:background="?attr/selectableItemBackgroundBorderless"
+                                android:contentDescription="@string/next_month"
+                                android:src="@drawable/ic_arrow_forward" />
+                            </LinearLayout>
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+                            <GridLayout
+                                android:id="@+id/month_grid"
+                                android:layout_width="match_parent"
+                                android:layout_height="0dp"
+                                android:layout_weight="1"
+                                android:columnCount="7"
+                                android:paddingStart="8dp"
+                                android:paddingEnd="8dp"
+                                android:paddingBottom="8dp" />
+
+                            <androidx.recyclerview.widget.RecyclerView
+                                android:id="@+id/month_day_events_recycler_view"
+                                style="@style/FastScroll"
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                android:paddingBottom="?attr/actionBarSize"
+                                android:clipToPadding="false"
+                                android:visibility="gone" />
+
+                            </LinearLayout>
+
+                        </LinearLayout>
+
+                    </ViewFlipper>
+
+                </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+                <com.google.android.material.appbar.AppBarLayout
+                    style="@style/AppBarLayoutStyle">
+
+                    <com.google.android.material.appbar.MaterialToolbar
+                        android:id="@+id/top_toolbar"
+                        style="@style/TopToolbar"
+                        app:navigationIcon="@drawable/ic_menu" />
+
+                    <com.google.android.material.progressindicator.LinearProgressIndicator
+                        android:id="@+id/sync_toolbar_progress"
+                        style="@style/SyncProgressIndicator" />
+
+                    </com.google.android.material.appbar.AppBarLayout>
+
+                    <com.google.android.material.bottomappbar.BottomAppBar
+                        android:id="@+id/bottom_toolbar"
+                        style="@style/BottomToolbar" />
+
+                    </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/prefs_keys.xml
+++ b/app/src/main/res/values/prefs_keys.xml
@@ -359,6 +359,22 @@
     <string name="pref_key_group_scheduled_with_today" translatable="false">pref_key_group_scheduled_with_today</string>
     <bool name="pref_default_group_scheduled_with_today" translatable="false">true</bool>
 
+    <string name="pref_key_calendar_month_text_size" translatable="false">pref_key_calendar_month_text_size</string>
+    <string name="pref_default_calendar_month_text_size" translatable="false">14</string>
+    <string-array name="calendar_text_sizes">
+        <item>@string/font_size_small</item>
+        <item>@string/font_size_default</item>
+        <item>@string/font_size_large</item>
+    </string-array>
+    <string-array name="calendar_text_sizes_values">
+        <item>10</item>
+        <item>12</item>
+        <item>14</item>
+    </string-array>
+
+    <string name="pref_key_calendar_show_book_name" translatable="false">pref_key_calendar_show_book_name</string>
+    <bool name="pref_default_calendar_show_book_name" translatable="false">true</bool>
+
     <string name="pref_key_selected_note_metadata" translatable="false">pref_key_selected_note_metadata</string>
     <string-array name="note_metadata">
         <item>@string/tags</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,6 +348,20 @@
     <string name="day">Day</string>
     <string name="week">Week</string>
     <string name="month">Month</string>
+    <string name="month_view">Month view</string>
+    <string name="agenda_view">Agenda view</string>
+    <string name="week_view">Week view</string>
+    <string name="previous_month">Previous month</string>
+    <string name="next_month">Next month</string>
+    <string name="calendar_views">Calendar views</string>
+    <string name="calendar_text_size">Calendar text size</string>
+    <string name="agenda_mode_agenda">Agenda</string>
+    <string name="agenda_mode_week">Week</string>
+    <string name="agenda_mode_month">Month</string>
+    <string name="calendar_show_book_name">Show notebook name in calendar</string>
+    <string name="monday">Monday</string>
+    <string name="sunday">Sunday</string>
+    <string name="calendar">Calendar</string>
     <string name="year">Year</string>
 
     <string name="repeater_dialog_title">Repeat</string>

--- a/app/src/main/res/xml/prefs_screen_look_and_feel.xml
+++ b/app/src/main/res/xml/prefs_screen_look_and_feel.xml
@@ -107,6 +107,19 @@
             android:title="@string/group_scheduled_with_today"
             android:summary="@string/group_scheduled_with_today_summary"
             android:defaultValue="@bool/pref_default_group_scheduled_with_today" />
+
+        <ListPreference
+            android:key="@string/pref_key_calendar_month_text_size"
+            android:title="@string/calendar_text_size"
+            android:entries="@array/calendar_text_sizes"
+            android:entryValues="@array/calendar_text_sizes_values"
+            android:defaultValue="@string/pref_default_calendar_month_text_size"
+            app:useSimpleSummaryProvider="true" />
+
+        <SwitchPreference
+            android:key="@string/pref_key_calendar_show_book_name"
+            android:title="@string/calendar_show_book_name"
+            android:defaultValue="@bool/pref_default_calendar_show_book_name" />
     </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
### Summary

Adds support for **month view** in Agenda queries, along with related appearance settings.

### Details

The `ad.DAYS` query now supports a month-based calendar view:

* `ad.DAYS` → default day-based agenda view
* `ad.DAYS:month` → renders a month calendar view

### Appearance Settings

New options have been added under the existing **Agenda** section in Look & Feel settings for the month view:

* Calendar text size
* Show notebook name in calendar

### Motivation

This change adds a month calendar view to Agenda queries, making it easier to visualize events over longer time spans in a familiar calendar format.

### Notes / Feedback

Feedback is welcome on the `ad.DAYS:month` naming and overall approach to extending the query system.

### Some screenshots

<img width="1080" height="2400" alt="Screenshot_20260513-135958" src="https://github.com/user-attachments/assets/ea07d5c9-c230-4bfe-a82f-a05e296c8843" />
<img width="1080" height="2400" alt="Screenshot_20260513-140013" src="https://github.com/user-attachments/assets/65626aab-c55c-46e4-95e4-ea7001f28b28" />
