### PR TITLE
Fix git cloning on Android 11+ due to FUSE O_EXCL restriction

### DIFF
--- a/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
+++ b/app/src/main/java/com/orgzly/android/prefs/AppPreferences.java
@@ -1054,7 +1054,10 @@ public class AppPreferences {
     }
     
     public static String defaultRepositoryStorageDirectory(Context context) {
-        File path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+        // Use app-specific external storage to avoid EPERM from FUSE on public external storage
+        // (Android 11+ FUSE layer for public dirs doesn't support O_EXCL used by JGit)
+        File externalFilesDir = context.getExternalFilesDir(null);
+        File path = externalFilesDir != null ? externalFilesDir : context.getFilesDir();
         return getStringFromSelector(
                 context, R.string.pref_key_git_default_repository_directory, path.toString());
     }

--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
@@ -224,8 +224,15 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
         if (Environment.getExternalStorageState() != Environment.MEDIA_MOUNTED) {
             return
         }
-        val externalPath = Environment.getExternalStorageDirectory().path
-        val orgzlyGitPath = File("$externalPath/orgzly-git/")
+        // On Android 11+, public external storage (/storage/emulated/0/) uses FUSE which
+        // doesn't support O_EXCL — required by JGit for atomic temp file creation during checkout.
+        // Use app-specific external storage which has FUSE passthrough.
+        val baseDir = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            getExternalFilesDir(null) ?: return
+        } else {
+            File(Environment.getExternalStorageDirectory().path)
+        }
+        val orgzlyGitPath = File(baseDir, "orgzly-git")
         var success = false
         try {
             success = orgzlyGitPath.mkdirs()
@@ -233,6 +240,13 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
         if (success || (orgzlyGitPath.exists() && orgzlyGitPath.list().size == 0)) {
             binding.activityRepoGitDirectory.setText(orgzlyGitPath.path)
         }
+    }
+
+    private fun isOnPublicExternalStorage(dir: File): Boolean {
+        val extDir = Environment.getExternalStorageDirectory().absolutePath
+        val appSpecificDir = getExternalFilesDir(null)?.absolutePath ?: return false
+        val path = dir.absolutePath
+        return path.startsWith(extDir) && !path.startsWith(appSpecificDir)
     }
 
     private fun setFromPreferences() {
@@ -296,6 +310,15 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
                 if (targetDirectory.list()!!.isNotEmpty()) {
                     binding.activityRepoGitDirectoryLayout.error =
                         getString(R.string.git_clone_error_target_not_empty)
+                    return
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                    isOnPublicExternalStorage(targetDirectory)) {
+                    val suggestedPath = getExternalFilesDir(null)?.let {
+                        File(it, targetDirectory.name).absolutePath
+                    } ?: targetDirectory.absolutePath
+                    binding.activityRepoGitDirectoryLayout.error =
+                        getString(R.string.git_clone_error_public_external_storage, suggestedPath)
                     return
                 }
                 val repoScheme = getRepoScheme()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,6 +192,7 @@
     <string name="git_auth_https_password_hint">Password</string>
     <!-- Git sync repo errors -->
     <!-- TODO: I don't think we can say more than this for ssh authentication failures, but we probably want to -->
+    <string name="git_clone_error_public_external_storage">This path is not supported on Android 11+. Use app storage instead, e.g.: %1$s</string>
     <string name="git_clone_error_invalid_repo">The remote address is not a git repo</string>
     <string name="git_clone_error_invalid_target_dir">The target directory does not exist</string>
     <string name="git_clone_error_target_not_empty">The target directory is not empty</string>


### PR DESCRIPTION
This PR resolves #200 

Android 11+ FUSE layer for public external storage (/storage/emulated/0/) doesn't support O_EXCL, which JGit requires for atomic temp file creation during checkout. App-specific dirs (Android/data/…) use FUSE passthrough where O_EXCL works correctly.

- Default repo path now uses getExternalFilesDir() on API 30+
- createDefaultRepoFolder() follows the same logic
- Cloning to a public external path shows an error with a suggested app-specific alternative path