### PR TITLE
Basic implementation of partially checked checkbox

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/views/richtext/RichText.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/richtext/RichText.kt
@@ -290,7 +290,12 @@ class RichText(context: Context, attrs: AttributeSet?) :
     override fun toggleCheckbox(checkboxSpan: CheckboxSpan) {
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, checkboxSpan)
 
-        val content = if (checkboxSpan.isChecked()) "[ ]" else "[X]"
+        // The normal toggle action only switches between [ ] and [X] as org-toggle-checkbox does.
+        val currentState = checkboxSpan.getState();
+        val content = when (currentState) {
+            CheckboxSpan.State.CHECKED -> "[ ]"
+            else -> "[X]"
+        }
 
         val replacement = OrgFormatter.checkboxSpanned(
             content, checkboxSpan.rawStart, checkboxSpan.rawEnd)

--- a/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
+++ b/app/src/main/java/com/orgzly/android/ui/views/style/CheckboxSpan.kt
@@ -7,10 +7,14 @@ import android.view.View
 import com.orgzly.android.ui.views.richtext.ActionableRichTextView
 
 /**
- * @param content is `[ ]` or `[X]`
- * @param rawStart is a position of dash
+ * @param content is `[ ]`, `[-]`, or `[X]`
+ * @param rawStart is the position of `[`.
  */
 class CheckboxSpan(val content: CharSequence, val rawStart: Int, val rawEnd: Int) : ClickableSpan() {
+
+    enum class State {
+        UNCHECKED, PARTIAL, CHECKED
+    }
 
     override fun onClick(view: View) {
         Log.d("CheckboxSpan", "Checkbox clicked on $view")
@@ -22,7 +26,11 @@ class CheckboxSpan(val content: CharSequence, val rawStart: Int, val rawEnd: Int
     override fun updateDrawState(tp: TextPaint) {
     }
 
-    fun isChecked(): Boolean {
-        return content[1] != ' '
+    fun getState(): State {
+        when (content[1]) {
+            '-' -> return State.PARTIAL
+            'X' -> return State.CHECKED
+            else -> return State.UNCHECKED
+        }
     }
 }

--- a/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
+++ b/app/src/main/java/com/orgzly/android/util/OrgFormatter.kt
@@ -55,7 +55,7 @@ object OrgFormatter {
     private val LOGBOOK_DRAWER_PATTERN = drawerPattern(LOGBOOK_DRAWER_NAME)
 
     private const val PLAIN_LIST_CHARS = "-\\+"
-    private val CHECKBOXES_PATTERN = Pattern.compile("""^\s*[$PLAIN_LIST_CHARS]\s+(\[[ X]])""", Pattern.MULTILINE)
+    private val CHECKBOXES_PATTERN = Pattern.compile("""^\s*[$PLAIN_LIST_CHARS]\s+(\[[ -X]])""", Pattern.MULTILINE)
 
     private const val INACTIVE_DATETIME = "(\\[[0-9]{4,}-[0-9]{2}-[0-9]{2} ?[^\\]\\r\\n>]*?[0-9]{1,2}:[0-9]{2}\\])"
     private val CLOCKED_TIMES_P = Pattern.compile("(CLOCK: *$INACTIVE_DATETIME) *(-- *$INACTIVE_DATETIME)?( *=> *[0-9]{1,4}:[0-9]{2})?[\\r\\n]*")


### PR DESCRIPTION
Fixes #858

We differentiate three states of checkboxes: unchecked, partially checked and checked. When toggled, both an unchecked and partially checked box become checked, and a checked one becomes unchecked. This is analogous to org-toggle-checkbox.
Partially checked boxes are also rendered in monospace.

# Limitation
Checklists in org-mode form a hierarchy. A checkbox can become checked based on the state of its subtree, e.g. it becomes partially checked when at least one checkbox in the subtree is partially or fully checked. In orgzly, checklists do not form a hierarchy so this is not implemented.

For example (compare also how cookies track the state. orgzly does not support cookies in checkboxes)
```
# in emacs
* Test [1/3] [33%]
- [X] item 0
- [-] item 1
- [-] item 2 [1/2] [50%]
  - [ ] subitem 0
  - [X] subitem 1

# in orgzly
* Test [2/5] [40%]
- [X] item 0
- [-] item 1
- [-] item 2
  - [ ] subitem 0
  - [X] subitem 1
```