### PR TITLE
feat: Allow OR for some conditions in simplified search

### DIFF
--- a/app/src/main/java/com/orgzly/android/query/SimpleFilter.kt
+++ b/app/src/main/java/com/orgzly/android/query/SimpleFilter.kt
@@ -13,7 +13,7 @@ data class SimpleFilter(
     val books: Set<String> = emptySet(),
 
     val excludeDone: Boolean = false,
-    val state: String? = null,
+    val state: Set<String> = emptySet(),
 
     val priority: String? = null,
 
@@ -35,7 +35,7 @@ data class SimpleFilterBuilder(
     val books: MutableSet<String> = mutableSetOf(),
 
     var excludeDone: Boolean = false,
-    var state: String? = null,
+    var state: MutableSet<String> = mutableSetOf(),
 
     var priority: String? = null,
 

--- a/app/src/main/java/com/orgzly/android/query/user/QueryPullReader.kt
+++ b/app/src/main/java/com/orgzly/android/query/user/QueryPullReader.kt
@@ -34,13 +34,30 @@ internal class QueryPullReader(
 
 private fun flattenCondition(condition: Condition): List<Condition> =
     when (condition) {
-        is Condition.And ->
-            condition.operands.flatMap(::flattenCondition)
+        is Condition.And -> {
+            val flattenedOperands = condition.operands.map(::flattenCondition)
+            if (flattenedOperands.count { it.any { c -> c is Condition.InBook } } > 1) {
+                throw UnsupportedSimpleFilterException("Multiple books must be joined by OR")
+            }
+            if (flattenedOperands.count { it.any { c -> c is Condition.HasState } } > 1) {
+                throw UnsupportedSimpleFilterException("Multiple states must be joined by OR")
+            }
+            flattenedOperands.flatten()
+        }
 
-        is Condition.Or ->
-            throw UnsupportedSimpleFilterException(
-                "OR conditions are unsupported"
-            )
+        is Condition.Or -> {
+            val flattenedOperands = condition.operands.flatMap(::flattenCondition)
+            val allInBook = flattenedOperands.all { it is Condition.InBook }
+            val allHasState = flattenedOperands.all { it is Condition.HasState }
+
+            if (allInBook || allHasState) {
+                flattenedOperands
+            } else {
+                throw UnsupportedSimpleFilterException(
+                    "OR conditions are unsupported"
+                )
+            }
+        }
 
         else ->
             listOf(condition)

--- a/app/src/main/java/com/orgzly/android/query/user/SimpleFilterMapper.kt
+++ b/app/src/main/java/com/orgzly/android/query/user/SimpleFilterMapper.kt
@@ -71,11 +71,8 @@ class SimpleFilterMapper @Inject constructor(
                 }
 
                 is Condition.HasState -> {
-                    if (reader.hasNextConditionOfType<Condition.HasState>())
-                        throw UnsupportedSimpleFilterException("Cannot represent multiple HasState")
-
                     rejectIf(c.not)
-                    result.state = c.state
+                    result.state += c.state
                 }
 
                 is Condition.HasStateType -> {
@@ -132,13 +129,13 @@ class SimpleFilterMapper @Inject constructor(
 
     fun toQuery(search: String, filter: SimpleFilter): Query {
         val conditions = buildList {
-            addAll(filter.books.map { Condition.InBook(it) })
+            addOrJoinedConditions(filter.books.map { Condition.InBook(it) })
 
             if (filter.excludeDone) {
                 add(Condition.HasStateType(StateType.DONE, true))
             }
 
-            filter.state?.let { add(Condition.HasState(it, false)) }
+            addOrJoinedConditions(filter.state.map { Condition.HasState(it) })
             filter.priority?.let { add(Condition.HasPriority(it)) }
             addAll(filter.tags.map { Condition.HasTag(it) })
 
@@ -170,6 +167,16 @@ class SimpleFilterMapper @Inject constructor(
             sortOrders = listOfNotNull(mapSimpleSortOrder(filter.sortOrder, filter.sortDescending)),
             options = Options(agendaDays = filter.agendaDays ?: 0)
         )
+    }
+
+    private fun <T: Condition> MutableList<Condition>.addOrJoinedConditions(
+        conditions: Collection<T>
+    ) {
+        when (conditions.size) {
+            0 -> {}
+            1 -> addAll(conditions)
+            else -> add(Condition.Or(conditions.toList()))
+        }
     }
 
     private inline fun <reified T> MutableList<Condition>.addDateConditions(

--- a/app/src/main/java/com/orgzly/android/ui/savedsearch/SearchFilterWidget.kt
+++ b/app/src/main/java/com/orgzly/android/ui/savedsearch/SearchFilterWidget.kt
@@ -590,8 +590,8 @@ private fun TagsFilter(
 
 @Composable
 private fun StateFilter(
-    currentState: String?,
-    onStateChange: (String?) -> Unit,
+    states: Set<String>,
+    onStateChange: (Set<String>) -> Unit,
     enabled: Boolean = true
 ) {
     val allStatesString by appPreference { AppPreferences.states(it) }
@@ -607,27 +607,27 @@ private fun StateFilter(
         stringResource(R.string.state),
         collapsed,
         { collapsed = it },
-        currentState != null,
+        states.isNotEmpty(),
         modifier = Modifier.fillMaxWidth()
     ) {
         Column(
             Modifier.padding(dropdownPadding),
             verticalArrangement = Arrangement.spacedBy(dropdownVerticalSpacing)
         ) {
-            RadioButtonFormLockup(
-                currentState == null,
-                onClick = {
-                    onStateChange(null)
-                },
-                stringResource(R.string.search_filter_state_none),
-                modifier = Modifier.fillMaxWidth(),
-                enabled = enabled
-            )
             for (state in allStates) {
-                RadioButtonFormLockup(
-                    state.equals(currentState, ignoreCase = true),
-                    onClick = {
-                        onStateChange(state)
+                CheckboxFormLockup(
+                    states.any {
+                        it.equals(state, ignoreCase = true)
+                    },
+                    onCheckedChange = {
+                        onStateChange(
+                            when (it) {
+                                true -> states + state
+                                else -> states.filterNot {
+                                    it.equals(state, ignoreCase = true)
+                                }.toSet()
+                            }
+                        )
                     },
                     state,
                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/orgzly/android/ui/savedsearch/SearchFilterWidget.kt
+++ b/app/src/main/java/com/orgzly/android/ui/savedsearch/SearchFilterWidget.kt
@@ -62,6 +62,7 @@ import com.orgzly.android.ui.compose.widgets.OrgzlyTonalButton
 import com.orgzly.android.ui.compose.widgets.RadioButtonFormLockup
 import com.orgzly.android.ui.compose.widgets.TextFieldHoistEffect
 import com.orgzly.android.ui.compose.widgets.painterIcon
+import kotlin.collections.any
 import androidx.compose.runtime.rememberUpdatedState
 
 @Composable
@@ -552,61 +553,13 @@ private fun TagsFilter(
     allTags: List<String>,
     enabled: Boolean = true
 ) {
-    var collapsed by remember { mutableStateOf(true) }
-    val extraTags = remember(allTags, tags) {
-        tags.toMutableSet().apply {
-            removeAll(allTags)
-        }.toSet()
-    }
-
-    FilterCollapsePanel(
+    GenericCheckboxFilter(
         stringResource(R.string.tags),
-        collapsed,
-        { collapsed = it },
-        tags.isNotEmpty(),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(
-            Modifier.padding(dropdownPadding),
-            verticalArrangement = Arrangement.spacedBy(dropdownVerticalSpacing)
-        ) {
-            for (tag in allTags) {
-                CheckboxFormLockup(
-                    tags.any {
-                        it.equals(tag, ignoreCase = true)
-                    },
-                    onCheckedChange = {
-                        onTagChange(
-                            when (it) {
-                                true -> tags + tag
-                                else -> tags.filterNot {
-                                    it.equals(tag, ignoreCase = true)
-                                }.toSet()
-                            }
-                        )
-                    },
-                    tag,
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = enabled
-                )
-            }
-            for (tag in extraTags) {
-                CheckboxFormLockup(
-                    true,
-                    onCheckedChange = {
-                        onTagChange(
-                            tags.filterNot {
-                                it.equals(tag, ignoreCase = true)
-                            }.toSet()
-                        )
-                    },
-                    tag,
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = enabled
-                )
-            }
-        }
-    }
+        tags,
+        onTagChange,
+        allTags,
+        enabled,
+    )
 }
 
 @Composable
@@ -623,61 +576,13 @@ private fun StateFilter(
         }
     }
 
-    val extraStates = remember(allStates, states) {
-        states.toMutableSet().apply {
-            removeAll(allStates)
-        }.toSet()
-    }
-
-    var collapsed by remember { mutableStateOf(true) }
-    FilterCollapsePanel(
+    GenericCheckboxFilter(
         stringResource(R.string.state),
-        collapsed,
-        { collapsed = it },
-        states.isNotEmpty(),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(
-            Modifier.padding(dropdownPadding),
-            verticalArrangement = Arrangement.spacedBy(dropdownVerticalSpacing)
-        ) {
-            for (state in allStates) {
-                CheckboxFormLockup(
-                    states.any {
-                        it.equals(state, ignoreCase = true)
-                    },
-                    onCheckedChange = {
-                        onStateChange(
-                            when (it) {
-                                true -> states + state
-                                else -> states.filterNot {
-                                    it.equals(state, ignoreCase = true)
-                                }.toSet()
-                            }
-                        )
-                    },
-                    state,
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = enabled
-                )
-            }
-            for (state in extraStates) {
-                CheckboxFormLockup(
-                    true,
-                    onCheckedChange = {
-                        onStateChange(
-                            states.filterNot {
-                                it.equals(state, ignoreCase = true)
-                            }.toSet()
-                        )
-                    },
-                    state,
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = enabled
-                )
-            }
-        }
-    }
+        states,
+        onStateChange,
+        allStates,
+        enabled,
+    )
 }
 
 @Composable
@@ -687,53 +592,72 @@ private fun BookFilter(
     allBooks: List<String>,
     enabled: Boolean = true
 ) {
+    GenericCheckboxFilter(
+        stringResource(R.string.notebooks),
+        books,
+        onBooksChange,
+        allBooks,
+        enabled,
+    )
+}
+
+@Composable
+private fun GenericCheckboxFilter(
+    title: String,
+    selected: Set<String>,
+    onSelectChange: (Set<String>) -> Unit,
+    allOptions: List<String>,
+    enabled: Boolean = true,
+) {
     var collapsed by remember { mutableStateOf(true) }
-    val extraBooks = remember(allBooks, books) {
-        books.toMutableSet().apply {
-            removeAll(allBooks)
-        }.toSet()
+    val extraOptions = remember(allOptions, selected) {
+        selected.filterNot { selected ->
+            allOptions.any { it.equals(selected, ignoreCase = true) }
+        }
     }
 
     FilterCollapsePanel(
-        stringResource(R.string.notebooks),
+        title,
         collapsed,
         { collapsed = it },
-        books.isNotEmpty(),
+        selected.isNotEmpty(),
         modifier = Modifier.fillMaxWidth()
     ) {
         Column(
             Modifier.padding(dropdownPadding),
             verticalArrangement = Arrangement.spacedBy(dropdownVerticalSpacing)
         ) {
-            for (book in allBooks) {
+            for (option in allOptions) {
                 CheckboxFormLockup(
-                    books.contains(book),
+                    selected.any {
+                        it.equals(option, ignoreCase = true)
+                    },
                     onCheckedChange = {
-                        onBooksChange(
+                        onSelectChange(
                             when (it) {
-                                true -> books + book
-                                else -> books.filterNot {
-                                    it == book
+                                true -> selected + option
+                                else -> selected.filterNot {
+                                    it == option
                                 }.toSet()
                             }
                         )
                     },
-                    book,
+                    option,
                     modifier = Modifier.fillMaxWidth(),
                     enabled = enabled
                 )
             }
-            for (book in extraBooks) {
+            for (option in extraOptions) {
                 CheckboxFormLockup(
                     true,
                     onCheckedChange = {
-                        onBooksChange(
-                            books.filterNot {
-                                it == book
+                        onSelectChange(
+                            selected.filterNot {
+                                it.equals(option, ignoreCase = true)
                             }.toSet()
                         )
                     },
-                    book,
+                    option,
                     modifier = Modifier.fillMaxWidth(),
                     enabled = enabled
                 )

--- a/app/src/main/java/com/orgzly/android/ui/savedsearch/SearchFilterWidget.kt
+++ b/app/src/main/java/com/orgzly/android/ui/savedsearch/SearchFilterWidget.kt
@@ -553,6 +553,12 @@ private fun TagsFilter(
     enabled: Boolean = true
 ) {
     var collapsed by remember { mutableStateOf(true) }
+    val extraTags = remember(allTags, tags) {
+        tags.toMutableSet().apply {
+            removeAll(allTags)
+        }.toSet()
+    }
+
     FilterCollapsePanel(
         stringResource(R.string.tags),
         collapsed,
@@ -584,6 +590,21 @@ private fun TagsFilter(
                     enabled = enabled
                 )
             }
+            for (tag in extraTags) {
+                CheckboxFormLockup(
+                    true,
+                    onCheckedChange = {
+                        onTagChange(
+                            tags.filterNot {
+                                it.equals(tag, ignoreCase = true)
+                            }.toSet()
+                        )
+                    },
+                    tag,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = enabled
+                )
+            }
         }
     }
 }
@@ -600,6 +621,12 @@ private fun StateFilter(
             (it.todoKeywords?.toList() ?: emptyList<String>()) +
             (it.doneKeywords?.toList() ?: emptyList<String>())
         }
+    }
+
+    val extraStates = remember(allStates, states) {
+        states.toMutableSet().apply {
+            removeAll(allStates)
+        }.toSet()
     }
 
     var collapsed by remember { mutableStateOf(true) }
@@ -634,6 +661,21 @@ private fun StateFilter(
                     enabled = enabled
                 )
             }
+            for (state in extraStates) {
+                CheckboxFormLockup(
+                    true,
+                    onCheckedChange = {
+                        onStateChange(
+                            states.filterNot {
+                                it.equals(state, ignoreCase = true)
+                            }.toSet()
+                        )
+                    },
+                    state,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = enabled
+                )
+            }
         }
     }
 }
@@ -646,6 +688,12 @@ private fun BookFilter(
     enabled: Boolean = true
 ) {
     var collapsed by remember { mutableStateOf(true) }
+    val extraBooks = remember(allBooks, books) {
+        books.toMutableSet().apply {
+            removeAll(allBooks)
+        }.toSet()
+    }
+
     FilterCollapsePanel(
         stringResource(R.string.notebooks),
         collapsed,
@@ -668,6 +716,21 @@ private fun BookFilter(
                                     it == book
                                 }.toSet()
                             }
+                        )
+                    },
+                    book,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = enabled
+                )
+            }
+            for (book in extraBooks) {
+                CheckboxFormLockup(
+                    true,
+                    onCheckedChange = {
+                        onBooksChange(
+                            books.filterNot {
+                                it == book
+                            }.toSet()
                         )
                     },
                     book,

--- a/app/src/test/java/com/orgzly/android/query/user/SimpleFilterMapperTest.kt
+++ b/app/src/test/java/com/orgzly/android/query/user/SimpleFilterMapperTest.kt
@@ -32,7 +32,7 @@ class SimpleFilterMapperTest {
         assertEquals("", simpleQuery.search)
         assertTrue(simpleQuery.filter.books.isEmpty())
         assertFalse(simpleQuery.filter.excludeDone)
-        assertNull(simpleQuery.filter.state)
+        assertTrue(simpleQuery.filter.state.isEmpty())
         assertNull(simpleQuery.filter.priority)
         assertTrue(simpleQuery.filter.tags.isEmpty())
         assertNull(simpleQuery.filter.event)
@@ -62,7 +62,7 @@ class SimpleFilterMapperTest {
         val simpleQuery = mapper.fromQuery(query)
 
         assertEquals(setOf("work"), simpleQuery.filter.books)
-        assertEquals("TODO", simpleQuery.filter.state)
+        assertEquals(setOf("TODO"), simpleQuery.filter.state)
         assertEquals("A", simpleQuery.filter.priority)
     }
 
@@ -85,7 +85,7 @@ class SimpleFilterMapperTest {
         val simpleQuery = mapper.fromQuery(query)
 
         assertEquals(setOf("work"), simpleQuery.filter.books)
-        assertEquals("TODO", simpleQuery.filter.state)
+        assertEquals(setOf("TODO"), simpleQuery.filter.state)
         assertEquals("A", simpleQuery.filter.priority)
         assertEquals(setOf("urgent"), simpleQuery.filter.tags)
         assertTrue(simpleQuery.filter.excludeDone)
@@ -200,7 +200,7 @@ class SimpleFilterMapperTest {
         val filter = SimpleFilter(
             books = setOf("personal"),
             excludeDone = true,
-            state = "NEXT",
+            state = setOf("NEXT"),
             priority = "B",
             tags = setOf("home", "work"),
             scheduled = RelativeDateOption.TODAY,

--- a/app/src/test/java/com/orgzly/android/query/user/SimpleFilterMapperTest.kt
+++ b/app/src/test/java/com/orgzly/android/query/user/SimpleFilterMapperTest.kt
@@ -167,7 +167,7 @@ class SimpleFilterMapperTest {
 
     @Test(expected = UnsupportedSimpleFilterException::class)
     fun `fromQuery - OR condition throws`() {
-        val query = Query(Condition.Or(listOf(Condition.InBook("a"), Condition.InBook("b"))))
+        val query = Query(Condition.Or(listOf(Condition.HasTag("a"), Condition.HasTag("b"))))
         mapper.fromQuery(query)
     }
 


### PR DESCRIPTION
## Changes
This pull request changes the parser/simplified search to represent OR conditions for `HasState` and `InBook`. This means that a query such as `(i.TODO OR i.NEXT)` is correctly parsed and represented in the UI, whereas previously it could only be written as an advanced query. For both conditions, since it is impossible for a note to have multiple states or exist in multiple books, it makes sense to extend the parser to represent this fact. On the other hand, `HasTag` continues to represent AND joined conditions, since a note can have multiple tags.

## Fixes
This pull request fixes multiple bugs created in #955 
* The search UI allows users to select multiple books for a search, however it represents them as ANDed conditions. Since a note cannot be in two books at once this behaviour was useless and confusing. Since they are now joined by OR, this is no longer an issue
* If a query contained an "invalid" tag, book, or state (i.e. one that was not represented in the set of all tags, books, and states), the filter would be marked as active, the condition would continue to apply, but there would be no checkbox available to deselect the "invalid" option. These "invalid" options are now treated as extra and presented at the bottom of known values.

## Notes
This change can be treated as a companion to #974 and implements one of the "Further work" items I discussed there. I have separated it out for the purpose of keeping the change surface small and allowing this smaller change to be merged without the other. I'm happy to combine the two if asked.