### PR TITLE
(feat) add share title and share content options to note share menu

### DIFF
--- a/app/src/main/java/com/orgzly/android/NotesOrgExporter.kt
+++ b/app/src/main/java/com/orgzly/android/NotesOrgExporter.kt
@@ -7,6 +7,7 @@ import com.orgzly.android.data.mappers.OrgMapper
 import com.orgzly.android.db.entity.Book
 import com.orgzly.android.db.entity.NoteView
 import com.orgzly.android.prefs.AppPreferences
+import com.orgzly.android.ui.note.NotePayload
 import com.orgzly.org.parser.OrgParserSettings
 import com.orgzly.org.parser.OrgParserWriter
 import java.io.File
@@ -51,6 +52,16 @@ class NotesOrgExporter(val dataRepository: DataRepository) {
             ?: throw IllegalArgumentException("Note with id $noteId not found")
 
         return exportNote(noteView, false)
+    }
+
+    /**
+     * Exports a [NotePayload] (in-memory, possibly unsaved note) to Org format string.
+     */
+    fun exportNote(notePayload: NotePayload): String {
+        val orgParserSettings = getOrgParserSettingsFromPreferences()
+        val orgWriter = OrgParserWriter(orgParserSettings)
+        val head = OrgMapper.toOrgHead(notePayload)
+        return orgWriter.whiteSpacedHead(head, 1, false)
     }
 
     /**

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
@@ -1065,15 +1065,18 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
     private enum class SharePart { NOTE, TITLE, CONTENT }
 
     private fun shareNotePart(part: SharePart) {
-        viewModel.noteId?.let { noteId ->
+        // Sync on-screen content to payload before sharing
+        updatePayloadFromViews()
+
+        viewModel.notePayload?.let { payload ->
             try {
                 val text = when (part) {
                     SharePart.NOTE ->
-                        NotesOrgExporter(dataRepository).exportNote(noteId)
+                        NotesOrgExporter(dataRepository).exportNote(payload)
                     SharePart.TITLE ->
-                        dataRepository.getNoteView(noteId)?.note?.title?.takeIf { it.isNotBlank() } ?: ""
+                        payload.title.takeIf { it.isNotBlank() } ?: ""
                     SharePart.CONTENT ->
-                        dataRepository.getNoteView(noteId)?.note?.content?.takeIf { it.isNotBlank() } ?: ""
+                        payload.content?.takeIf { it.isNotBlank() } ?: ""
                 }
 
                 if (text.isNotEmpty()) {

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
@@ -371,8 +371,16 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
                 userDelete()
             }
 
-            R.id.share -> {
-                shareNote()
+            R.id.share_note -> {
+                shareNotePart(SharePart.NOTE)
+            }
+
+            R.id.share_title -> {
+                shareNotePart(SharePart.TITLE)
+            }
+
+            R.id.share_content -> {
+                shareNotePart(SharePart.CONTENT)
             }
 
             R.id.sync -> {
@@ -1054,19 +1062,28 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
         viewModel.requestNoteDelete()
     }
 
-    private fun shareNote() {
+    private enum class SharePart { NOTE, TITLE, CONTENT }
+
+    private fun shareNotePart(part: SharePart) {
         viewModel.noteId?.let { noteId ->
             try {
-                val exporter = NotesOrgExporter(dataRepository)
-                val orgContent = exporter.exportNote(noteId)
-
-                val shareIntent = Intent().apply {
-                    action = Intent.ACTION_SEND
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, orgContent)
+                val text = when (part) {
+                    SharePart.NOTE ->
+                        NotesOrgExporter(dataRepository).exportNote(noteId)
+                    SharePart.TITLE ->
+                        dataRepository.getNoteView(noteId)?.note?.title?.takeIf { it.isNotBlank() } ?: ""
+                    SharePart.CONTENT ->
+                        dataRepository.getNoteView(noteId)?.note?.content?.takeIf { it.isNotBlank() } ?: ""
                 }
 
-                startActivity(Intent.createChooser(shareIntent, getString(R.string.share)))
+                if (text.isNotEmpty()) {
+                    val shareIntent = Intent().apply {
+                        action = Intent.ACTION_SEND
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, text)
+                    }
+                    startActivity(Intent.createChooser(shareIntent, getString(R.string.share)))
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to share note", e)
                 activity?.showSnackbar(R.string.failed_sharing_note)

--- a/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NotesFragment.kt
@@ -1,7 +1,9 @@
 package com.orgzly.android.ui.notes
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.widget.PopupWindow
@@ -10,6 +12,7 @@ import androidx.appcompat.app.AlertDialog
 import com.orgzly.BuildConfig
 import com.orgzly.R
 import com.orgzly.android.App
+import com.orgzly.android.NotesOrgExporter
 import com.orgzly.android.data.DataRepository
 import com.orgzly.android.ui.CommonFragment
 import com.orgzly.android.ui.NotePlace
@@ -214,6 +217,44 @@ abstract class NotesFragment : CommonFragment(), TimestampDialogFragment.OnDateT
         fun onClockIn(noteIds: Set<Long>)
         fun onClockOut(noteIds: Set<Long>)
         fun onClockCancel(noteIds: Set<Long>)
+    }
+
+    enum class SharePart { NOTE, TITLE, CONTENT }
+
+    fun shareNoteParts(ids: Set<Long>, part: SharePart) {
+        try {
+            val exporter = NotesOrgExporter(dataRepository)
+
+            val text = when (part) {
+                SharePart.NOTE -> ids.mapNotNull { id ->
+                    try {
+                        exporter.exportNote(id)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to export note $id", e)
+                        null
+                    }
+                }.joinToString("")
+
+                SharePart.TITLE -> ids.mapNotNull { id ->
+                    dataRepository.getNoteView(id)?.note?.title?.takeIf { it.isNotBlank() }
+                }.joinToString("\n")
+
+                SharePart.CONTENT -> ids.mapNotNull { id ->
+                    dataRepository.getNoteView(id)?.note?.content?.takeIf { it.isNotBlank() }
+                }.joinToString("\n")
+            }
+
+            if (text.isNotEmpty()) {
+                val shareIntent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_TEXT, text)
+                }
+                startActivity(Intent.createChooser(shareIntent, getString(R.string.share)))
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to share notes", e)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
@@ -21,7 +21,6 @@ import com.orgzly.BuildConfig
 import com.orgzly.R
 import com.orgzly.android.App
 import com.orgzly.android.BookUtils
-import com.orgzly.android.NotesOrgExporter
 import com.orgzly.android.db.NotesClipboard
 import com.orgzly.android.db.entity.Book
 import com.orgzly.android.db.entity.NoteView
@@ -482,34 +481,6 @@ class BookFragment :
         viewModel.requestNotesDelete(ids)
     }
 
-    private fun shareNotes(ids: Set<Long>) {
-        try {
-            val exporter = NotesOrgExporter(dataRepository)
-            val exportedNotes = mutableListOf<String>()
-
-            for (noteId in ids) {
-                try {
-                    exportedNotes.add(exporter.exportNote(noteId))
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to export note $noteId", e)
-                }
-            }
-
-            val content = exportedNotes.joinToString("")
-
-            if (content.isNotEmpty()) {
-                val shareIntent = Intent().apply {
-                    action = Intent.ACTION_SEND
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, content)
-                }
-                startActivity(Intent.createChooser(shareIntent, getString(R.string.share)))
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to share notes", e)
-        }
-    }
-
     override fun getCurrentDrawerItemId(): String {
         return getDrawerItemId(mBookId)
     }
@@ -886,8 +857,18 @@ class BookFragment :
                 viewModel.appBar.toMode(APP_BAR_DEFAULT_MODE)
             }
 
-            R.id.share -> {
-                shareNotes(ids)
+            R.id.share_note -> {
+                shareNoteParts(ids, SharePart.NOTE)
+                viewModel.appBar.toMode(APP_BAR_DEFAULT_MODE)
+            }
+
+            R.id.share_title -> {
+                shareNoteParts(ids, SharePart.TITLE)
+                viewModel.appBar.toMode(APP_BAR_DEFAULT_MODE)
+            }
+
+            R.id.share_content -> {
+                shareNoteParts(ids, SharePart.CONTENT)
                 viewModel.appBar.toMode(APP_BAR_DEFAULT_MODE)
             }
 

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.lifecycle.ViewModelProvider
 import cl.emilym.compose.units.rdp
 import com.orgzly.R
-import com.orgzly.android.NotesOrgExporter
 import com.orgzly.android.sync.SyncRunner
 import com.orgzly.android.ui.compose.base.bootstrapContent
 import com.orgzly.android.ui.compose.widgets.Icons
@@ -132,8 +131,16 @@ abstract class QueryFragment :
             R.id.focus ->
                 listener?.onNoteFocusInBookRequest(ids.first())
 
-            R.id.share -> {
-                shareNotes(ids)
+            R.id.share_note -> {
+                shareNoteParts(ids, SharePart.NOTE)
+            }
+
+            R.id.share_title -> {
+                shareNoteParts(ids, SharePart.TITLE)
+            }
+
+            R.id.share_content -> {
+                shareNoteParts(ids, SharePart.CONTENT)
             }
 
             R.id.sync -> {
@@ -143,34 +150,6 @@ abstract class QueryFragment :
             R.id.activity_action_settings -> {
                 startActivity(Intent(context, SettingsActivity::class.java))
             }
-        }
-    }
-
-    private fun shareNotes(ids: Set<Long>) {
-        try {
-            val exporter = NotesOrgExporter(dataRepository)
-            val exportedNotes = mutableListOf<String>()
-
-            for (noteId in ids) {
-                try {
-                    exportedNotes.add(exporter.exportNote(noteId))
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to export note $noteId", e)
-                }
-            }
-
-            val content = exportedNotes.joinToString("")
-
-            if (content.isNotEmpty()) {
-                val shareIntent = Intent().apply {
-                    action = Intent.ACTION_SEND
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, content)
-                }
-                startActivity(Intent.createChooser(shareIntent, getString(R.string.share)))
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to share notes", e)
         }
     }
 

--- a/app/src/main/res/drawable-anydpi/ic_article.xml
+++ b/app/src/main/res/drawable-anydpi/ic_article.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,3H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2zM14,17H7v-2h7v2zM17,13H7v-2h10v2zM17,9H7V7h10v2z"/>
+</vector>

--- a/app/src/main/res/drawable-anydpi/ic_title.xml
+++ b/app/src/main/res/drawable-anydpi/ic_title.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M5,4h14v3h-6v13h-2V7H5V4z"/>
+</vector>

--- a/app/src/main/res/menu/book_cab_top.xml
+++ b/app/src/main/res/menu/book_cab_top.xml
@@ -76,7 +76,25 @@
         android:id="@+id/share"
         app:showAsAction="never"
         android:icon="@drawable/ic_share"
-        android:title="@string/share"/>
+        android:title="@string/share">
+
+        <menu>
+            <item
+                android:id="@+id/share_note"
+                android:icon="@drawable/ic_notes"
+                android:title="@string/share_note"/>
+
+            <item
+                android:id="@+id/share_title"
+                android:icon="@drawable/ic_title"
+                android:title="@string/share_title"/>
+
+            <item
+                android:id="@+id/share_content"
+                android:icon="@drawable/ic_article"
+                android:title="@string/share_content"/>
+        </menu>
+    </item>
 
     <item
         android:id="@+id/delete_note"

--- a/app/src/main/res/menu/note_actions.xml
+++ b/app/src/main/res/menu/note_actions.xml
@@ -78,7 +78,25 @@
         android:id="@+id/share"
         android:icon="@drawable/ic_share"
         app:showAsAction="never"
-        android:title="@string/share" />
+        android:title="@string/share">
+
+        <menu>
+            <item
+                android:id="@+id/share_note"
+                android:icon="@drawable/ic_notes"
+                android:title="@string/share_note"/>
+
+            <item
+                android:id="@+id/share_title"
+                android:icon="@drawable/ic_title"
+                android:title="@string/share_title"/>
+
+            <item
+                android:id="@+id/share_content"
+                android:icon="@drawable/ic_article"
+                android:title="@string/share_content"/>
+        </menu>
+    </item>
 
     <item
         android:id="@+id/sync"

--- a/app/src/main/res/menu/query_cab_top.xml
+++ b/app/src/main/res/menu/query_cab_top.xml
@@ -29,6 +29,24 @@
         android:id="@+id/share"
         app:showAsAction="never"
         android:icon="@drawable/ic_share"
-        android:title="@string/share"/>
+        android:title="@string/share">
+
+        <menu>
+            <item
+                android:id="@+id/share_note"
+                android:icon="@drawable/ic_notes"
+                android:title="@string/share_note"/>
+
+            <item
+                android:id="@+id/share_title"
+                android:icon="@drawable/ic_title"
+                android:title="@string/share_title"/>
+
+            <item
+                android:id="@+id/share_content"
+                android:icon="@drawable/ic_article"
+                android:title="@string/share_content"/>
+        </menu>
+    </item>
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -689,6 +689,9 @@
     <string name="log_major_events">Log major events</string>
     <string name="logs">Logs</string>
     <string name="share">Share</string>
+    <string name="share_note">Share note</string>
+    <string name="share_title">Share title</string>
+    <string name="share_content">Share content</string>
     <string name="refresh_data">Refresh</string>
 
     <string name="clock">Clock</string>


### PR DESCRIPTION
I needed a feature to copy the note content to clipboard so I can paste it elsewhere, so I implemented it.

The alternative was to open a note, go to content field, select some part of the context text, long press, find and click "select all" and then press copy. All too cumbersome compared to the copy content action item.

While I was at it, I also added "copy title", in case someone might find it useful.