### PR TITLE
No longer add an extra hour on default time

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/dialogs/TimestampDialogViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/dialogs/TimestampDialogViewModel.kt
@@ -35,9 +35,7 @@ class TimestampDialogViewModel(val timeType: TimeType, orgDateTime: String?) : C
                 val orgDateTime = OrgDateTime.parseOrNull(str)
 
                 // TODO: Make default configurable
-                val defaultTime = Calendar.getInstance().apply {
-                    add(Calendar.HOUR, 1)
-                }
+                val defaultTime = Calendar.getInstance()
 
                 val cal = if (orgDateTime != null) {
                     orgDateTime.calendar


### PR DESCRIPTION
Hello, 

I just want to modify the behavior that when creating a new inlined time stamp, an extra hour is added to the current time.

To me, adding this extra hour seems an arbitrary choice, and the comment also mentioned that this should be a configurable choice.

Removing the extra hour makes the function behaves similar to what `org-timestamp` does in Emacs.

I also believe people are more likely to use this function to record the current time, rather than an hour later.