### PR TITLE
fix: Correctly mark widget query intent as raw

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -194,6 +194,7 @@ public class MainActivity extends CommonActivity
             long bookId = getIntent().getLongExtra(AppIntent.EXTRA_BOOK_ID, 0L);
             long noteId = getIntent().getLongExtra(AppIntent.EXTRA_NOTE_ID, 0L);
             String queryString = getIntent().getStringExtra(AppIntent.EXTRA_QUERY_STRING);
+            boolean isRawQuery = getIntent().getBooleanExtra(AppIntent.EXTRA_IS_RAW_QUERY, false);
 
             if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG, bookId, noteId, queryString);
 
@@ -206,7 +207,13 @@ public class MainActivity extends CommonActivity
                     DisplayManager.displayExistingNote(getSupportFragmentManager(), bookId, noteId);
                 }
             } else if (queryString != null) {
-                DisplayManager.displayQuery(getSupportFragmentManager(), queryString, null);
+                DisplayManager.displayQuery(
+                        getSupportFragmentManager(),
+                        queryString,
+                        null,
+                        isRawQuery,
+                        true
+                );
 
             } else {
                 handleOrgProtocolIntent(getIntent());
@@ -255,7 +262,7 @@ public class MainActivity extends CommonActivity
 
             @Override
             public void onQuery(@NonNull String query) {
-                viewModel.displayQuery(query);
+                viewModel.displayQuery(query, true);
             }
 
             @Override
@@ -423,7 +430,10 @@ public class MainActivity extends CommonActivity
                 DisplayManager.displayQuery(
                         getSupportFragmentManager(),
                         thisAction.getQuery(),
-                        null);
+                        null,
+                        thisAction.isRawQuery(),
+                        true
+                );
             }
         });
 
@@ -998,13 +1008,13 @@ public class MainActivity extends CommonActivity
                 case AppIntent.ACTION_OPEN_QUERY: {
                     String query = intent.getStringExtra(AppIntent.EXTRA_QUERY_STRING);
                     String searchName = intent.getStringExtra(AppIntent.EXTRA_SEARCH_NAME);
-                    Boolean isRawQuery = intent.getBooleanExtra(AppIntent.EXTRA_IS_RAW_QUERY, false);
+                    boolean isRawQuery = intent.getBooleanExtra(AppIntent.EXTRA_IS_RAW_QUERY, false);
                     DisplayManager.displayQuery(
                             getSupportFragmentManager(),
                             query,
                             searchName,
-                            true,
-                            isRawQuery
+                            isRawQuery,
+                            true
                     );
                     break;
                 }

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivityViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivityViewModel.kt
@@ -71,8 +71,8 @@ class MainActivityViewModel(private val dataRepository: DataRepository) : Common
         }
     }
 
-    fun displayQuery(query: String) {
-        navigationActions.postValue(MainNavigationAction.DisplayQuery(query))
+    fun displayQuery(query: String, isRawQuery: Boolean) {
+        navigationActions.postValue(MainNavigationAction.DisplayQuery(query, isRawQuery))
     }
 
     fun followLinkToNoteOrBookWithProperty(name: String, value: String) {
@@ -162,5 +162,5 @@ sealed class MainNavigationAction {
     data class OpenBookFocusNote(val bookId: Long, val noteId: Long, val foldRest: Boolean) : MainNavigationAction()
     data class OpenNote(val bookId: Long, val noteId: Long) : MainNavigationAction()
     data class OpenFile(val file: File) : MainNavigationAction()
-    data class DisplayQuery(val query: String) : MainNavigationAction()
+    data class DisplayQuery(val query: String, val isRawQuery: Boolean) : MainNavigationAction()
 }

--- a/app/src/main/java/com/orgzly/android/widgets/ListWidgetProvider.java
+++ b/app/src/main/java/com/orgzly/android/widgets/ListWidgetProvider.java
@@ -90,6 +90,7 @@ public class ListWidgetProvider extends AppWidgetProvider {
                 Intent serviceIntent = new Intent(context, ListWidgetService.class);
                 serviceIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
                 serviceIntent.putExtra(AppIntent.EXTRA_QUERY_STRING, savedSearch.getQuery());
+                serviceIntent.putExtra(AppIntent.EXTRA_IS_RAW_QUERY, true);
                 serviceIntent.putExtra(AppIntent.EXTRA_SAVED_SEARCH_ID, savedSearch.getId());
                 serviceIntent.setData(Uri.parse(serviceIntent.toUri(Intent.URI_INTENT_SCHEME)));
 
@@ -119,6 +120,7 @@ public class ListWidgetProvider extends AppWidgetProvider {
                 // Logo - open query
                 Intent openIntent = Intent.makeRestartActivityTask(new ComponentName(context, MainActivity.class));
                 openIntent.putExtra(AppIntent.EXTRA_QUERY_STRING, savedSearch.getQuery());
+                openIntent.putExtra(AppIntent.EXTRA_IS_RAW_QUERY, true);
                 openIntent.setData(Uri.parse(serviceIntent.toUri(Intent.URI_INTENT_SCHEME)));
                 remoteViews.setOnClickPendingIntent(R.id.list_widget_header_logo, PendingIntent.getActivity(context, 0, openIntent, ActivityUtils.immutable(PendingIntent.FLAG_UPDATE_CURRENT)));
 


### PR DESCRIPTION
Fixes #999, where navigating to the app through clicking on the logo in the widget incorrectly interprets the query as a simple search, rather than an advanced query. This PR corrects the interpretation, as well as a few other problem areas.