### PR TITLE
Upgrade JGit to the latest release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,7 @@ android {
 
     packagingOptions {
         resources {
-            excludes += ['META-INF/DEPENDENCIES', 'plugin.properties']
+            excludes += ['META-INF/DEPENDENCIES', 'plugin.properties', 'OSGI-INF/l10n/plugin.properties']
         }
     }
 
@@ -180,7 +180,9 @@ dependencies {
     testImplementation(project(":shared-test"))
     testImplementation "androidx.test.ext:junit:$versions.android_test_ext_junit"
     testImplementation "org.robolectric:robolectric:$versions.robolectric"
-    testImplementation "io.github.atetzner:webdav-embedded-server:$versions.webdav_embedded_server"
+    testImplementation("io.github.atetzner:webdav-embedded-server:$versions.webdav_embedded_server") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 
     // Android instrumented tests
     androidTestImplementation(project(":shared-test"))
@@ -233,6 +235,9 @@ dependencies {
     }
     implementation("androidx.security:security-crypto:$versions.security_crypto") {
         because 'SSH key generation'
+    }
+    implementation("net.i2p.crypto:eddsa:$versions.net_i2p_crypto_eddsa") {
+        because 'SSH Ed25519 key generation'
     }
     implementation("androidx.biometric:biometric-ktx:$versions.biometric_ktx") {
         because 'Protect SSH key with biometric prompt'

--- a/app/src/androidTest/java/com/orgzly/android/espresso/GitRepoTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/GitRepoTest.kt
@@ -1,5 +1,6 @@
 package com.orgzly.android.espresso
 
+import android.os.Build
 import androidx.core.net.toUri
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
@@ -23,6 +24,7 @@ import com.orgzly.android.ui.main.MainActivity
 import org.eclipse.jgit.api.Git
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,6 +50,7 @@ class GitRepoTest : OrgzlyTest() {
         val gitPreferences = GitPreferencesFromRepoPrefs(repoPreferences)
         gitWorkingTree = File(gitPreferences.repositoryFilepath())
         gitWorkingTree.mkdirs()
+        Assume.assumeTrue((Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU)) // Test should never run on API <33
         GitRepo.ensureRepositoryExists(gitPreferences, true, null)
         testUtils.setupRepo(RepoType.GIT, repo.url)
     }

--- a/app/src/androidTest/java/com/orgzly/android/espresso/SshKeyCreationTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/SshKeyCreationTest.kt
@@ -1,5 +1,6 @@
 package com.orgzly.android.espresso
 
+import android.os.Build
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
@@ -9,12 +10,12 @@ import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import com.orgzly.R
 import com.orgzly.BuildConfig
+import com.orgzly.R
 import com.orgzly.android.OrgzlyTest
+import com.orgzly.android.RetryTestRule
 import com.orgzly.android.espresso.util.EspressoUtils
 import com.orgzly.android.ui.main.MainActivity
-import com.orgzly.android.RetryTestRule
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
@@ -42,7 +43,8 @@ class SshKeyCreationTest(private val param: Parameter) : OrgzlyTest() {
 
     @Test
     fun testCreateUnprotectedKey() {
-        Assume.assumeFalse(BuildConfig.IS_GIT_REMOVED);
+        Assume.assumeFalse(BuildConfig.IS_GIT_REMOVED)
+        Assume.assumeTrue((Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU)) // Test should never run on API <33
         ActivityScenario.launch(MainActivity::class.java).use {
             EspressoUtils.onActionItemClick(R.id.activity_action_settings, R.string.settings)
             EspressoUtils.clickSetting(R.string.app)

--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
@@ -558,6 +558,8 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
         override fun endTask() {
 
         }
+
+        override fun showDuration(p0: Boolean) {}
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/settings/SettingsFragment.kt
@@ -129,8 +129,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             }
         }
 
-        // Disable Git repos completely on API < 23 and in the Play Store build
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N || BuildConfig.IS_GIT_REMOVED) {
+        // Disable Git repos completely on API < 33 and in the Play Store build
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || BuildConfig.IS_GIT_REMOVED) {
             preference(R.string.pref_key_git_is_enabled)?.let {
                 preferenceScreen.removePreference(it)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ buildscript {
 
     versions.okhttp_digest = '3.1.1'
 
-    versions.jgit = '5.13.5.202508271544-r'
+    versions.jgit = '7.7.0.202606012155-r'
 
     versions.security_crypto = '1.1.0'
 
@@ -81,6 +81,8 @@ buildscript {
     versions.robolectric = '4.16.1'
 
     versions.webdav_embedded_server = '0.2.1'
+
+    versions.net_i2p_crypto_eddsa = '0.3.0'
 
     ext.versions = versions
 

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -44,6 +44,7 @@ android {
 
     packagingOptions {
         resources.merges.add("plugin.properties")
+        resources.merges.add("OSGI-INF/l10n/plugin.properties")
     }
 }
 


### PR DESCRIPTION
This version of JGit contains a patch (contributed by me) which ensures that Git's "garbage collection" works on Android.

Sadly, JGit v7 cannot run on API <33 (Android <13), because of missing Java classes. But going by our Google Play statistics, less than 13 % of our user base still runs Android <13, and my impression is that the Git repository type is not very popular, so my guess is that very few people will be upset by this.

Closes #468.