### PR TITLE
Fix dead hamburger in note editor hosted by ShareActivity

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
@@ -275,10 +275,18 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
 
             ActivityUtils.keepScreenOnUpdateMenuItem(activity, menu)
 
-            setNavigationIcon(R.drawable.ic_menu)
+            if (activity is ShareActivity) {
+                setNavigationIcon(R.drawable.ic_close)
 
-            setNavigationOnClickListener {
-                sharedMainActivityViewModel.openDrawer()
+                setNavigationOnClickListener {
+                    userCancel()
+                }
+            } else {
+                setNavigationIcon(R.drawable.ic_menu)
+
+                setNavigationOnClickListener {
+                    sharedMainActivityViewModel.openDrawer()
+                }
             }
 
             if (viewModel.notePayload == null) {


### PR DESCRIPTION
When NoteFragment is shown inside ShareActivity (sharing text, widget capture, capture templates), the top toolbar's hamburger called sharedMainActivityViewModel.openDrawer(). That event is only observed by MainActivity, so the icon did nothing in ShareActivity.

Show a close icon there instead, wired to userCancel() (the same handler as the back button, preserving the unsaved-changes prompt), which finishes the activity via onNoteCanceled(). MainActivity keeps the hamburger + openDrawer() behavior.