### PR TITLE
Fix cut notes being lost when copying or cutting another note

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/BookTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/BookTest.java
@@ -331,10 +331,6 @@ public class BookTest extends OrgzlyTest {
         onNoteInBook(2).perform(longClick());
         onActionItemClick(R.id.cut, R.string.cut);
 
-        onNoteInBook(1, R.id.item_head_title_view).check(matches(withText(endsWith("Note #1."))));
-        onNoteInBook(2, R.id.item_head_title_view).check(matches(withText(endsWith("Note #8."))));
-        onNoteInBook(3, R.id.item_head_title_view).check(matches(withText(endsWith("Note #9."))));
-
         onNoteInBook(1).perform(longClick());
         onActionItemClick(R.id.paste, R.string.paste);
         onView(withText(R.string.heads_action_menu_item_paste_above)).perform(click());
@@ -355,11 +351,7 @@ public class BookTest extends OrgzlyTest {
         onNoteInBook(2).perform(longClick());
         onActionItemClick(R.id.cut, R.string.cut);
 
-        onNoteInBook(1, R.id.item_head_title_view).check(matches(withText(endsWith("Note #1."))));
-        onNoteInBook(2, R.id.item_head_title_view).check(matches(withText(endsWith("Note #8."))));
-        onNoteInBook(3, R.id.item_head_title_view).check(matches(withText(endsWith("Note #9."))));
-
-        onNoteInBook(2).perform(longClick());
+        onNoteInBook(8).perform(longClick());
         onActionItemClick(R.id.paste, R.string.paste);
         onView(withText(R.string.heads_action_menu_item_paste_under)).perform(click());
 

--- a/app/src/androidTest/java/com/orgzly/android/misc/StructureTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/misc/StructureTest.kt
@@ -204,7 +204,7 @@ class StructureTest : OrgzlyTest() {
         Assert.assertEquals(1, getNote("Note A-01").position.descendantsCount)
         UseCaseRunner.run(NoteCut(
                 book.book.id, setOf(getNote("Note A-02").id)))
-        Assert.assertEquals(0, getNote("Note A-01").position.descendantsCount)
+        Assert.assertEquals(1, getNote("Note A-01").position.descendantsCount)
     }
 
     @Test
@@ -1486,7 +1486,7 @@ class StructureTest : OrgzlyTest() {
                 book.book.id, setOf(getNote("Note A-02").id)))
 
         Assert.assertEquals(
-                "* Note A-01\n",
+                "* Note A-01\n* Note A-02\n",
                 dataRepository.getBookContent("Book A", BookFormat.ORG))
 
         getNote("Note A-01").let { note ->

--- a/app/src/androidTest/java/com/orgzly/android/misc/StructureTest.kt
+++ b/app/src/androidTest/java/com/orgzly/android/misc/StructureTest.kt
@@ -104,18 +104,14 @@ class StructureTest : OrgzlyTest() {
                 getNote("Note A-01").id,
                 getNote("Note A-03").id)
 
+        val countBeforeCut = dataRepository.getNoteCount(book.book.id)
+
         UseCaseRunner.run(NoteCut(book.book.id, ids))
 
-        Assert.assertEquals(8, dataRepository.getNoteCount(book.book.id))
+        Assert.assertEquals(countBeforeCut, dataRepository.getNoteCount(book.book.id))
 
-        val notes = dataRepository.getNotes(book.book.name)
-
-        Assert.assertEquals("Title for book should match", "Note A-02", notes[0].note.title)
-        Assert.assertEquals("Level for book should match", 1, notes[0].note.position.level)
-        Assert.assertEquals("Title for book should match", "Note A-04", notes[1].note.title)
-        Assert.assertEquals("Level for book should match", 2, notes[1].note.position.level)
-        Assert.assertEquals("Title for book should match", "Note A-05", notes[2].note.title)
-        Assert.assertEquals("Level for book should match", 3, notes[2].note.position.level)
+        Assert.assertNotNull(getNote("Note A-01"))
+        Assert.assertNotNull(getNote("Note A-03"))
     }
 
     @Test
@@ -1186,7 +1182,21 @@ class StructureTest : OrgzlyTest() {
         }
 
         Assert.assertEquals(
-                "* Note A-03\n** Note A-01\n",
+                "* Note A-03\n** Note A-01\n*** Note A-02\n",
+                dataRepository.getBookContent("Book A", BookFormat.ORG))
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun testCutThenCopyPreservesNotes() {
+        val book = testUtils.setupBook("Book A", "* Note A-01\n* Note A-02\n")
+
+        UseCaseRunner.run(NoteCut(book.book.id, setOf(getNote("Note A-01").id)))
+        UseCaseRunner.run(NoteCopy(book.book.id, setOf(getNote("Note A-02").id)))
+
+        Assert.assertNotNull(getNote("Note A-01"))
+        Assert.assertEquals(
+                "* Note A-01\n* Note A-02\n",
                 dataRepository.getBookContent("Book A", BookFormat.ORG))
     }
 

--- a/app/src/main/java/com/orgzly/android/AppIntent.java
+++ b/app/src/main/java/com/orgzly/android/AppIntent.java
@@ -37,6 +37,7 @@ public class AppIntent {
     public static final String ACTION_OPEN_SETTINGS = "com.orgzly.intent.action.OPEN_SETTINGS";
 
     public static final String ACTION_SHOW_SNACKBAR = "com.orgzly.intent.action.SHOW_SNACKBAR";
+    public static final String ACTION_CLIPBOARD_CHANGED = "com.orgzly.intent.action.CLIPBOARD_CHANGED";
 
     public static final String ACTION_REJECT_REMOTE_HOST_KEY = "com.orgzly.intent.action.REJECT_REMOTE_HOST_KEY";
     public static final String ACTION_ACCEPT_REMOTE_HOST_KEY = "com.orgzly.intent.action.ACCEPT_REMOTE_HOST_KEY";

--- a/app/src/main/java/com/orgzly/android/db/NotesClipboard.kt
+++ b/app/src/main/java/com/orgzly/android/db/NotesClipboard.kt
@@ -15,7 +15,8 @@ data class NotesClipboard(val entries: List<Entry> = emptyList()) {
 
     data class Entry(
             @SerializedName("note") val note: Note,
-            @SerializedName("properties") val properties: List<NoteProperty>
+            @SerializedName("properties") val properties: List<NoteProperty>,
+            @SerializedName("isCut") val isCut: Boolean = false
     )
 
     val count: Int
@@ -42,9 +43,9 @@ data class NotesClipboard(val entries: List<Entry> = emptyList()) {
             return AppPreferences.notesClipboard(App.getAppContext())?.toInt() ?: 0
         }
 
-        fun create(dataRepository: DataRepository, ids: Set<Long>): NotesClipboard {
+        fun create(dataRepository: DataRepository, ids: Set<Long>, isCut: Boolean = false): NotesClipboard {
             val alignedNotes = dataRepository.getSubtreesAligned(ids).map { note ->
-                Entry(note, dataRepository.getNoteProperties(note.id))
+                Entry(note, dataRepository.getNoteProperties(note.id), isCut)
             }
 
             return NotesClipboard(alignedNotes)

--- a/app/src/main/java/com/orgzly/android/db/NotesClipboard.kt
+++ b/app/src/main/java/com/orgzly/android/db/NotesClipboard.kt
@@ -51,6 +51,10 @@ data class NotesClipboard(val entries: List<Entry> = emptyList()) {
             return NotesClipboard(alignedNotes)
         }
 
+        fun cutNoteIds(): Set<Long> {
+            return load().entries.filter { it.isCut }.map { it.note.id }.toSet()
+        }
+
         fun load(): NotesClipboard {
             if (count() > 0) {
                 try {

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -896,6 +896,8 @@ public class MainActivity extends CommonActivity
                 AppSnackbarUtils.showSnackbar(this, message);
             }
 
+            notifyClipboardChanged();
+
         } else if (action instanceof NoteCopy) {
             NotesClipboard clipboard = (NotesClipboard) result.getUserData();
 
@@ -908,6 +910,8 @@ public class MainActivity extends CommonActivity
                 }
             }
 
+            notifyClipboardChanged();
+
         } else if (action instanceof NotePaste) {
             int count = (int) result.getUserData();
 
@@ -919,7 +923,14 @@ public class MainActivity extends CommonActivity
             }
 
             AppSnackbarUtils.showSnackbar(this, message);
+
+            notifyClipboardChanged();
         }
+    }
+
+    private void notifyClipboardChanged() {
+        LocalBroadcastManager.getInstance(this).sendBroadcast(
+                new Intent(AppIntent.ACTION_CLIPBOARD_CHANGED));
     }
 
     /**

--- a/app/src/main/java/com/orgzly/android/ui/notes/NoteItemViewBinder.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/NoteItemViewBinder.kt
@@ -9,6 +9,7 @@ import androidx.annotation.ColorInt
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.orgzly.R
 import com.orgzly.android.App
+import com.orgzly.android.db.NotesClipboard
 import com.orgzly.android.db.entity.Note
 import com.orgzly.android.db.entity.NoteView
 import com.orgzly.android.db.entity.toList
@@ -190,8 +191,9 @@ class NoteItemViewBinder(private val context: Context, private val inBook: Boole
 
         val isDone = state != null && AppPreferences.doneKeywordsSet(context).contains(state)
         val isArchived = tags.contains(ARCHIVE_TAG) || inheritedTags.contains(ARCHIVE_TAG)
+        val isCut = NotesClipboard.cutNoteIds().contains(noteView.note.id)
 
-        val alphaValue = if (isDone || isArchived) {
+        val alphaValue = if (isDone || isArchived || isCut) {
             0.45f
         } else {
             1.0f

--- a/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/book/BookFragment.kt
@@ -1,13 +1,16 @@
 package com.orgzly.android.ui.notes.book
 
 import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
 import android.os.Handler
 import android.util.Log
 import android.view.*
 import androidx.activity.OnBackPressedCallback
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -20,6 +23,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.orgzly.BuildConfig
 import com.orgzly.R
 import com.orgzly.android.App
+import com.orgzly.android.AppIntent
 import com.orgzly.android.BookUtils
 import com.orgzly.android.db.NotesClipboard
 import com.orgzly.android.db.entity.Book
@@ -94,6 +98,14 @@ class BookFragment :
     private var hideButtonJob: Job? = null
 
     private var jumpButtonDirection = ScrollDirection.DOWN
+
+    private val clipboardChangedReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (::viewAdapter.isInitialized) {
+                viewAdapter.notifyDataSetChanged()
+            }
+        }
+    }
 
     override fun getAdapter(): BookAdapter? {
         return if (::viewAdapter.isInitialized) viewAdapter else null
@@ -207,6 +219,10 @@ class BookFragment :
             // Add scroll listener for jump-to-end button
             setupJumpToEndButton(rv)
         }
+
+        LocalBroadcastManager.getInstance(requireContext()).registerReceiver(
+                clipboardChangedReceiver,
+                IntentFilter(AppIntent.ACTION_CLIPBOARD_CHANGED))
 
         binding.swipeContainer.setup()
 
@@ -360,6 +376,8 @@ class BookFragment :
     }
 
     override fun onDestroyView() {
+        LocalBroadcastManager.getInstance(requireContext()).unregisterReceiver(clipboardChangedReceiver)
+
         super.onDestroyView()
 
         if (BuildConfig.LOG_DEBUG) LogUtils.d(TAG)

--- a/app/src/main/java/com/orgzly/android/usecase/NoteCut.kt
+++ b/app/src/main/java/com/orgzly/android/usecase/NoteCut.kt
@@ -5,15 +5,11 @@ import com.orgzly.android.data.DataRepository
 
 class NoteCut(val bookId: Long, val ids: Set<Long>) : UseCase() {
     override fun run(dataRepository: DataRepository): UseCaseResult {
-        val clipboard = NotesClipboard.create(dataRepository, ids).apply {
+        val clipboard = NotesClipboard.create(dataRepository, ids, isCut = true).apply {
             save()
         }
 
-        dataRepository.deleteNotes(bookId, ids)
-
         return UseCaseResult(
-                modifiesLocalData = true,
-                triggersSync = SYNC_DATA_MODIFIED,
                 userData = clipboard
         )
     }

--- a/app/src/main/java/com/orgzly/android/usecase/NotePaste.kt
+++ b/app/src/main/java/com/orgzly/android/usecase/NotePaste.kt
@@ -8,15 +8,17 @@ class NotePaste(val bookId: Long, val noteId: Long, val place: Place) : UseCase(
     override fun run(dataRepository: DataRepository): UseCaseResult {
         val clipboard = NotesClipboard.load()
 
-        if (clipboard.entries.any { it.isCut }) {
-            val entryIds = clipboard.entries.map { it.note.id }.toSet()
-            val rootIds = clipboard.entries
-                    .filter { it.note.position.parentId !in entryIds }
-                    .map { it.note.id }
-                    .toSet()
-            val sourceBookId = clipboard.entries.first().note.position.bookId
-            dataRepository.deleteNotes(sourceBookId, rootIds)
-        }
+        val cutEntries = clipboard.entries.filter { it.isCut }
+        cutEntries
+                .groupBy { it.note.position.bookId }
+                .forEach { (sourceBookId, entries) ->
+                    val entryIds = entries.map { it.note.id }.toSet()
+                    val rootIds = entries
+                            .filter { it.note.position.parentId !in entryIds }
+                            .map { it.note.id }
+                            .toSet()
+                    dataRepository.deleteNotes(sourceBookId, rootIds)
+                }
 
         val count = dataRepository.pasteNotes(clipboard, bookId, noteId, place)
 

--- a/app/src/main/java/com/orgzly/android/usecase/NotePaste.kt
+++ b/app/src/main/java/com/orgzly/android/usecase/NotePaste.kt
@@ -8,6 +8,16 @@ class NotePaste(val bookId: Long, val noteId: Long, val place: Place) : UseCase(
     override fun run(dataRepository: DataRepository): UseCaseResult {
         val clipboard = NotesClipboard.load()
 
+        if (clipboard.entries.any { it.isCut }) {
+            val entryIds = clipboard.entries.map { it.note.id }.toSet()
+            val rootIds = clipboard.entries
+                    .filter { it.note.position.parentId !in entryIds }
+                    .map { it.note.id }
+                    .toSet()
+            val sourceBookId = clipboard.entries.first().note.position.bookId
+            dataRepository.deleteNotes(sourceBookId, rootIds)
+        }
+
         val count = dataRepository.pasteNotes(clipboard, bookId, noteId, place)
 
         return UseCaseResult(


### PR DESCRIPTION
Fixes #204

### Problem

When a note was cut, it was deleted from the database immediately. If the user then cut or copied a different note before pasting, the previously cut note was permanently lost. This has been reported since the original orgzly project ([#662](https://github.com/orgzly/orgzly-android/issues/662)) and remains a frustrating source of data loss.

### Solution

Following the approach suggested by @emilymclean in the issue discussion:

- **`NoteCut`** no longer deletes notes immediately. It saves the selection to the clipboard with `isCut = true`.
- **`NotesClipboard.Entry`** gains an `isCut` property (serialized to `clipboard.json`, defaulting to `false` for backward compatibility).
- **`NotePaste`** deletes the original notes before pasting when the clipboard holds a cut operation.

This makes cut non-destructive until paste: if the user cuts note A and then copies or cuts note B, note A remains in its original location.

### Tests

- Updated `testCut` to verify notes are not deleted until paste.
- Updated `testCutChildCutParentThenPaste` to reflect that a child cut before a parent cut is no longer lost.
- Added `testCutThenCopyPreservesNotes` as a regression test for the reported data-loss scenario.