### PR TITLE
Save checkbox toggles immediately in single note view

### DIFF
--- a/app/src/androidTest/java/com/orgzly/android/espresso/MiscTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/MiscTest.java
@@ -750,12 +750,23 @@ public class MiscTest extends OrgzlyTest {
             onView(allOf(withId(R.id.content_view), withText(containsString("- [X] Item"))))
                     .check(matches(isDisplayed()));
 
-            SystemClock.sleep(500);
+            long deadline = SystemClock.uptimeMillis() + 5000;
+            boolean saved = false;
+            while (SystemClock.uptimeMillis() < deadline) {
+                com.orgzly.android.db.entity.Note note = dataRepository.getLastNote("Title");
+                if (note != null && note.getContent() != null && note.getContent().contains("- [X] Item")) {
+                    saved = true;
+                    break;
+                }
+                SystemClock.sleep(50);
+            }
+            assertTrue(saved);
 
             pressBack();
+            onNoteInBook(1).perform(click());
 
-            onNoteInBook(1, R.id.item_head_content_view)
-                    .check(matches(allOf(isDisplayed(), withText(containsString("- [X] Item")))));
+            onView(allOf(withId(R.id.content_view), withText(containsString("- [X] Item"))))
+                    .check(matches(isDisplayed()));
         }
     }
 

--- a/app/src/androidTest/java/com/orgzly/android/espresso/MiscTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/MiscTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.junit.Assert.assertTrue;
 
 import android.app.Activity;
@@ -761,6 +762,8 @@ public class MiscTest extends OrgzlyTest {
                 SystemClock.sleep(50);
             }
             assertTrue(saved);
+
+            getInstrumentation().waitForIdleSync();
 
             pressBack();
             onNoteInBook(1).perform(click());

--- a/app/src/androidTest/java/com/orgzly/android/espresso/MiscTest.java
+++ b/app/src/androidTest/java/com/orgzly/android/espresso/MiscTest.java
@@ -749,6 +749,13 @@ public class MiscTest extends OrgzlyTest {
 
             onView(allOf(withId(R.id.content_view), withText(containsString("- [X] Item"))))
                     .check(matches(isDisplayed()));
+
+            SystemClock.sleep(500);
+
+            pressBack();
+
+            onNoteInBook(1, R.id.item_head_content_view)
+                    .check(matches(allOf(isDisplayed(), withText(containsString("- [X] Item")))));
         }
     }
 

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
@@ -61,6 +61,8 @@ import com.orgzly.android.ui.util.invisibleIf
 import com.orgzly.android.ui.util.invisibleUnless
 import com.orgzly.android.ui.views.richtext.RichText
 import com.orgzly.android.ui.views.richtext.RichTextEdit
+import com.orgzly.android.usecase.NoteUpdateContent
+import com.orgzly.android.usecase.UseCaseRunner
 import com.orgzly.android.util.LogUtils
 import com.orgzly.android.util.OrgFormatter
 import com.orgzly.android.util.SpaceTokenizer
@@ -233,6 +235,20 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
 
         binding.content.setOnUserTextChangeListener { str ->
             binding.content.setSourceText(str)
+
+            if (viewModel.isNew()) {
+                viewModel.updatePayloadContent(str)
+            } else {
+                val useCase = NoteUpdateContent(viewModel.noteId, str)
+
+                App.EXECUTORS.diskIO().execute {
+                    UseCaseRunner.run(useCase)
+
+                    App.EXECUTORS.mainThread().execute {
+                        viewModel.onContentSavedImmediately(str)
+                    }
+                }
+            }
         }
 
         /*

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteFragment.kt
@@ -61,8 +61,6 @@ import com.orgzly.android.ui.util.invisibleIf
 import com.orgzly.android.ui.util.invisibleUnless
 import com.orgzly.android.ui.views.richtext.RichText
 import com.orgzly.android.ui.views.richtext.RichTextEdit
-import com.orgzly.android.usecase.NoteUpdateContent
-import com.orgzly.android.usecase.UseCaseRunner
 import com.orgzly.android.util.LogUtils
 import com.orgzly.android.util.OrgFormatter
 import com.orgzly.android.util.SpaceTokenizer
@@ -235,20 +233,7 @@ class NoteFragment : CommonFragment(), View.OnClickListener, TimestampDialogFrag
 
         binding.content.setOnUserTextChangeListener { str ->
             binding.content.setSourceText(str)
-
-            if (viewModel.isNew()) {
-                viewModel.updatePayloadContent(str)
-            } else {
-                val useCase = NoteUpdateContent(viewModel.noteId, str)
-
-                App.EXECUTORS.diskIO().execute {
-                    UseCaseRunner.run(useCase)
-
-                    App.EXECUTORS.mainThread().execute {
-                        viewModel.onContentSavedImmediately(str)
-                    }
-                }
-            }
+            viewModel.onUserContentChange(str)
         }
 
         /*

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteViewModel.kt
@@ -158,6 +158,15 @@ class NoteViewModel(
             properties = properties)
     }
 
+    fun updatePayloadContent(content: String) {
+        notePayload = notePayload?.copy(content = content)
+    }
+
+    fun onContentSavedImmediately(content: String) {
+        updatePayloadContent(content)
+        notePayload?.let { originalHash = notePayloadHash(it) }
+    }
+
     fun updatePayloadState(state: String?) {
         notePayload?.let {
             notePayload = NoteBuilder.changeState(App.getAppContext(), it, state)

--- a/app/src/main/java/com/orgzly/android/ui/note/NoteViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/note/NoteViewModel.kt
@@ -22,6 +22,7 @@ import com.orgzly.android.usecase.BookSparseTreeForNote
 import com.orgzly.android.usecase.NoteCreate
 import com.orgzly.android.usecase.NoteDelete
 import com.orgzly.android.usecase.NoteUpdate
+import com.orgzly.android.usecase.NoteUpdateContent
 import com.orgzly.android.usecase.UseCaseRunner
 import com.orgzly.android.util.MiscUtils
 import com.orgzly.org.OrgProperties
@@ -162,7 +163,23 @@ class NoteViewModel(
         notePayload = notePayload?.copy(content = content)
     }
 
-    fun onContentSavedImmediately(content: String) {
+    fun onUserContentChange(content: String) {
+        if (isNew()) {
+            updatePayloadContent(content)
+        } else {
+            App.EXECUTORS.diskIO().execute {
+                catchAndPostError {
+                    UseCaseRunner.run(NoteUpdateContent(noteId, content))
+
+                    App.EXECUTORS.mainThread().execute {
+                        onContentSavedImmediately(content)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onContentSavedImmediately(content: String) {
         updatePayloadContent(content)
         notePayload?.let { originalHash = notePayloadHash(it) }
     }


### PR DESCRIPTION
### Summary

Checkbox toggles in the note detail view are now persisted immediately, matching the behavior already present in the note list view. This prevents data loss when leaving the note without pressing Done (e.g. via back navigation, Android gestures, or switching apps).

### Problem

In the list view, toggling a checkbox updates the UI and saves to the database right away via `NoteUpdateContent`. In the single note view, the same toggle updated the UI but only kept the change in memory until the user pressed the Done button. Navigating away could discard the change, and the unsaved-changes warning was inconsistent because `notePayload` was not updated on toggle.

### Solution

- Wire `NoteFragment`'s `onUserTextChange` listener to call `NoteUpdateContent` for existing notes (same pattern as `NoteItemViewBinder`)
- Add `NoteViewModel.updatePayloadContent()` and `onContentSavedImmediately()` to keep in-memory state aligned with what was saved
- For new notes (not yet in the database), only update the in-memory payload
- Extend `testClickingCheckboxInNoteDetails` to verify the toggle persists after navigating back to the list

### Testing

- `./gradlew :app:compileFdroidDebugKotlin` — passes
- `MiscTest.testClickingCheckboxInNoteDetails` — updated to assert persistence after `pressBack()`