### PR TITLE
Hide "Refine Search" button on saved search queries

### DIFF
--- a/app/src/main/java/com/orgzly/android/AppIntent.java
+++ b/app/src/main/java/com/orgzly/android/AppIntent.java
@@ -50,6 +50,8 @@ public class AppIntent {
     public static final String EXTRA_NOTE_CONTENT = "com.orgzly.intent.extra.NOTE_CONTENT";
     public static final String EXTRA_QUERY_STRING = "com.orgzly.intent.extra.QUERY_STRING";
     public static final String EXTRA_IS_RAW_QUERY = "com.orgzly.intent.extra.IS_RAW_QUERY";
+    public static final String EXTRA_QUERY_FORCE_HIDE_REFINE_BUTTON =
+            "com.orgzly.intent.extra.QUERY_FORCE_HIDE_REFINE_BUTTON";
     public static final String EXTRA_SEARCH_NAME = "com.orgzly.intent.extra.SEARCH_NAME";
     public static final String EXTRA_PROPERTY_NAME  = "com.orgzly.intent.extra.PROPERTY_NAME";
     public static final String EXTRA_PROPERTY_VALUE  = "com.orgzly.intent.extra.PROPERTY_VALUE";

--- a/app/src/main/java/com/orgzly/android/ui/DisplayManager.java
+++ b/app/src/main/java/com/orgzly/android/ui/DisplayManager.java
@@ -219,34 +219,53 @@ public class DisplayManager {
     }
 
     public static void displayQuery(FragmentManager fragmentManager, @NonNull String queryString) {
-        displayQuery(fragmentManager, queryString, null);
+        displayQuery(fragmentManager, queryString, null, false, true);
     }
 
-    public static void displayQuery(FragmentManager fragmentManager, @NonNull String queryString, @Nullable String searchName) {
-        displayQuery(fragmentManager, queryString, searchName, false, true);
+    /**
+     * @deprecated Use displayQuery(FragmentManager, DisplayQueryArgs)
+     */
+    public static void displayQuery(FragmentManager fragmentManager, @NonNull String queryString, @Nullable String searchName, boolean isRawQuery, boolean addToBackStack) {
+        displayQuery(
+                fragmentManager,
+                new DisplayQueryArgs(queryString)
+                        .setSearchName(searchName)
+                        .setRawQuery(isRawQuery)
+                        .setAddToBackStack(addToBackStack)
+        );
     }
 
-    public static void displayQuery(FragmentManager fragmentManager, @NonNull String queryString, @Nullable String searchName, @NonNull boolean isRawQuery, @NonNull boolean addToBackStack) {
+    public static void displayQuery(FragmentManager fragmentManager, DisplayQueryArgs args) {
+        assert args.queryString != null;
+
         // If the same query is already displayed, don't do anything.
         String displayedQuery = getDisplayedQuery(fragmentManager);
-        if (displayedQuery != null && displayedQuery.equals(queryString)) {
+        if (displayedQuery != null && displayedQuery.equals(args.queryString)) {
             return;
         }
 
         // Parse query
         QueryParser queryParser = new InternalQueryParser();
-        Query query = queryParser.parse(queryString);
+        Query query = queryParser.parse(args.queryString);
 
         Fragment fragment;
         String tag;
 
         // Display agenda or query fragment
         if (query.getOptions().getAgendaDays() > 0) {
-            fragment = AgendaFragment.getInstance(queryString, searchName, isRawQuery);
+            fragment = AgendaFragment.getInstance(
+                    args.queryString,
+                    args.searchName,
+                    args.isRawQuery,
+                    args.forceHideRefineButton);
             tag = AgendaFragment.FRAGMENT_TAG;
 
         } else {
-            fragment = SearchFragment.getInstance(queryString, searchName, isRawQuery);
+            fragment = SearchFragment.getInstance(
+                    args.queryString,
+                    args.searchName,
+                    args.isRawQuery,
+                    args.forceHideRefineButton);
             tag = SearchFragment.FRAGMENT_TAG;
         }
 
@@ -255,7 +274,7 @@ public class DisplayManager {
                 R.id.single_pane_container,
                 fragment,
                 tag,
-                addToBackStack);
+                args.addToBackStack);
     }
 
     public static void displayEditor(FragmentManager fragmentManager, Book book) {
@@ -322,4 +341,42 @@ public class DisplayManager {
             return null;
         }
     }
+
+    public static class DisplayQueryArgs {
+        private String queryString;
+        private String searchName = null;
+        private boolean isRawQuery = false;
+        private boolean addToBackStack = true;
+        private boolean forceHideRefineButton = false;
+
+        public DisplayQueryArgs(@NonNull String queryString) {
+            this.queryString = queryString;
+        }
+
+        public DisplayQueryArgs setQueryString(@NonNull String queryString) {
+            this.queryString = queryString;
+            return this;
+        }
+
+        public DisplayQueryArgs setSearchName(@Nullable String searchName) {
+            this.searchName = searchName;
+            return this;
+        }
+
+        public DisplayQueryArgs setRawQuery(boolean rawQuery) {
+            isRawQuery = rawQuery;
+            return this;
+        }
+
+        public DisplayQueryArgs setAddToBackStack(boolean addToBackStack) {
+            this.addToBackStack = addToBackStack;
+            return this;
+        }
+
+        public DisplayQueryArgs setForceHideRefineButton(boolean forceHideRefineButton) {
+            this.forceHideRefineButton = forceHideRefineButton;
+            return this;
+        }
+    }
+
 }

--- a/app/src/main/java/com/orgzly/android/ui/drawer/DrawerNavigationView.kt
+++ b/app/src/main/java/com/orgzly/android/ui/drawer/DrawerNavigationView.kt
@@ -90,6 +90,7 @@ internal class DrawerNavigationView(
             intent.putExtra(AppIntent.EXTRA_QUERY_STRING, savedSearch.query)
             intent.putExtra(AppIntent.EXTRA_SEARCH_NAME, savedSearch.name)
             intent.putExtra(AppIntent.EXTRA_IS_RAW_QUERY, true)
+            intent.putExtra(AppIntent.EXTRA_QUERY_FORCE_HIDE_REFINE_BUTTON, true)
 
             val id = generateRandomUniqueId()
             val item = menu.add(R.id.drawer_group, id, 1, savedSearch.name)

--- a/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
+++ b/app/src/main/java/com/orgzly/android/ui/main/MainActivity.java
@@ -1028,14 +1028,19 @@ public class MainActivity extends CommonActivity
 
                 case AppIntent.ACTION_OPEN_QUERY: {
                     String query = intent.getStringExtra(AppIntent.EXTRA_QUERY_STRING);
+                    if (query == null) return;
                     String searchName = intent.getStringExtra(AppIntent.EXTRA_SEARCH_NAME);
                     boolean isRawQuery = intent.getBooleanExtra(AppIntent.EXTRA_IS_RAW_QUERY, false);
+                    boolean forceHideRefineButton = intent.getBooleanExtra(
+                            AppIntent.EXTRA_QUERY_FORCE_HIDE_REFINE_BUTTON,
+                            false
+                    );
                     DisplayManager.displayQuery(
                             getSupportFragmentManager(),
-                            query,
-                            searchName,
-                            isRawQuery,
-                            true
+                            new DisplayManager.DisplayQueryArgs(query)
+                                    .setRawQuery(isRawQuery)
+                                    .setForceHideRefineButton(forceHideRefineButton)
+                                    .setSearchName(searchName)
                     );
                     break;
                 }

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
@@ -4,26 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import android.view.Menu
 import android.widget.Toast
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.TextFieldLineLimits
-import androidx.compose.foundation.text.input.clearText
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
 import androidx.lifecycle.ViewModelProvider
-import cl.emilym.compose.units.rdp
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.orgzly.R
@@ -32,10 +14,6 @@ import com.orgzly.android.sync.SyncRunner
 import com.orgzly.android.ui.capture.CaptureTemplate
 import com.orgzly.android.ui.capture.CaptureTemplateResolver
 import com.orgzly.android.ui.capture.getDisplayName
-import com.orgzly.android.ui.compose.base.bootstrapContent
-import com.orgzly.android.ui.compose.widgets.Icons
-import com.orgzly.android.ui.compose.widgets.OrgzlySearchTextField
-import com.orgzly.android.ui.compose.widgets.painterIcon
 import com.orgzly.android.ui.dialogs.TimestampDialogFragment
 import com.orgzly.android.ui.drawer.DrawerItem
 import com.orgzly.android.ui.main.SharedMainActivityViewModel
@@ -215,6 +193,7 @@ abstract class QueryFragment :
         const val ARG_IS_RAW_QUERY = "is_raw_query"
         const val ARG_QUERY_NAME = "query_name"
 
+        const val ARG_FORCE_HIDE_REFINE_BUTTON = "show_refine_button"
         fun getDrawerItemId(query: String?): String {
             return "$TAG $query"
         }

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModel.kt
@@ -81,6 +81,7 @@ class QueryViewModel @AssistedInject constructor(
     private val filterMapper: SimpleFilterMapper,
     @Assisted private val initialQuery: String,
     @Assisted private val isRawQuery: Boolean,
+    @Assisted private val forceHideRefineButton: Boolean,
     @Assisted private val owner: QueryViewModelOwner,
     @Assisted context: Context
 ) : CommonViewModel() {
@@ -137,7 +138,7 @@ class QueryViewModel @AssistedInject constructor(
                 else -> ViewState.LOADED
             },
             isSimpleMode,
-            appBarMode == APP_BAR_DEFAULT_MODE,
+            appBarMode == APP_BAR_DEFAULT_MODE && !forceHideRefineButton,
             queryParser.parse(query).options.agendaDays
         )
     }.state(QueryState.default)

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModel.kt
@@ -80,8 +80,8 @@ class QueryViewModel @AssistedInject constructor(
     private val queryBuilder: InternalQueryBuilder,
     private val filterMapper: SimpleFilterMapper,
     @Assisted private val initialQuery: String,
-    @Assisted private val isRawQuery: Boolean,
-    @Assisted private val forceHideRefineButton: Boolean,
+    @Assisted("isRawQuery") private val isRawQuery: Boolean,
+    @Assisted("forceHideRefineButton") private val forceHideRefineButton: Boolean,
     @Assisted private val owner: QueryViewModelOwner,
     @Assisted context: Context
 ) : CommonViewModel() {

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModelFactory.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModelFactory.kt
@@ -11,6 +11,7 @@ interface QueryViewModelFactory : ViewModelProvider.Factory {
     fun create(
         initialQuery: String,
         isRawQuery: Boolean,
+        forceHideRefineButton: Boolean,
         owner: QueryViewModelOwner,
         context: Context
     ): QueryViewModel
@@ -20,12 +21,19 @@ interface QueryViewModelFactory : ViewModelProvider.Factory {
             assistedFactory: QueryViewModelFactory,
             initialQuery: String,
             isRawQuery: Boolean,
+            forceHideRefineButton: Boolean,
             owner: QueryViewModelOwner,
             context: Context
         ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 @Suppress("UNCHECKED_CAST")
-                return assistedFactory.create(initialQuery, isRawQuery, owner, context) as T
+                return assistedFactory.create(
+                    initialQuery,
+                    isRawQuery,
+                    forceHideRefineButton,
+                    owner,
+                    context
+                ) as T
             }
         }
     }

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModelFactory.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModelFactory.kt
@@ -3,15 +3,17 @@ package com.orgzly.android.ui.notes.query
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 
 @AssistedFactory
 interface QueryViewModelFactory : ViewModelProvider.Factory {
 
     fun create(
         initialQuery: String,
-        isRawQuery: Boolean,
-        forceHideRefineButton: Boolean,
+        @Assisted("isRawQuery") isRawQuery: Boolean,
+        @Assisted("forceHideRefineButton") forceHideRefineButton: Boolean,
         owner: QueryViewModelOwner,
         context: Context
     ): QueryViewModel

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
@@ -62,6 +62,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
             viewModelFactory,
             requireArguments().getString(ARG_QUERY) ?: "",
             requireArguments().getBoolean(ARG_IS_RAW_QUERY, false),
+            requireArguments().getBoolean(ARG_FORCE_HIDE_REFINE_BUTTON, false),
             QueryViewModelOwner.AGENDA,
             requireContext()
         )
@@ -385,7 +386,12 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
         }
 
         @JvmStatic
-        fun getInstance(query: String, queryName: String? = null, isRawQuery: Boolean = false): AgendaFragment {
+        fun getInstance(
+            query: String,
+            queryName: String? = null,
+            isRawQuery: Boolean = false,
+            forceHideRefineButton: Boolean = false,
+        ): AgendaFragment {
             val fragment = AgendaFragment()
 
             val args = Bundle()
@@ -394,6 +400,7 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
             if (queryName != null) {
                 args.putString(ARG_QUERY_NAME, queryName)
             }
+            args.putBoolean(ARG_FORCE_HIDE_REFINE_BUTTON, forceHideRefineButton)
             fragment.arguments = args
 
             return fragment

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/search/SearchFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/search/SearchFragment.kt
@@ -59,6 +59,7 @@ class SearchFragment : QueryFragment(), OnViewHolderClickListener<NoteView> {
             viewModelFactory,
             requireArguments().getString(ARG_QUERY) ?: "",
             requireArguments().getBoolean(ARG_IS_RAW_QUERY, false),
+            requireArguments().getBoolean(ARG_FORCE_HIDE_REFINE_BUTTON, false),
             QueryViewModelOwner.SEARCH,
             requireContext()
         )
@@ -364,7 +365,12 @@ class SearchFragment : QueryFragment(), OnViewHolderClickListener<NoteView> {
         }
 
         @JvmStatic
-        fun getInstance(query: String, queryName: String? = null, isRawQuery: Boolean = false): SearchFragment {
+        fun getInstance(
+            query: String,
+            queryName: String? = null,
+            isRawQuery: Boolean = false,
+            forceHideRefineButton: Boolean = false,
+        ): SearchFragment {
             val fragment = SearchFragment()
 
             val args = Bundle()
@@ -373,6 +379,7 @@ class SearchFragment : QueryFragment(), OnViewHolderClickListener<NoteView> {
             if (queryName != null) {
                 args.putString(ARG_QUERY_NAME, queryName)
             }
+            args.putBoolean(ARG_FORCE_HIDE_REFINE_BUTTON, forceHideRefineButton)
             fragment.arguments = args
 
             return fragment


### PR DESCRIPTION
Hides the "Refine Search" button from the `QueryFragment`s (i.e. `SearchFragment` and `AgendaFragment`) when navigated to from a saved search. As raised by @markokocic, users rarely modify saved searches once they are created and find the button to be unnecessary clutter in their workflow. I have intentionally added no configuration for this change. Resolves #1029.

There are more refinements I intend to contribute soon (some of which I suggested in Marko's issue), but I am quite busy right now and this was a quick change :) 