### PR TITLE
Allow creating multiple git repos by incrementing orgzly-git directory name

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
@@ -232,13 +232,13 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
         } else {
             File(Environment.getExternalStorageDirectory().path)
         }
-        val orgzlyGitPath = File(baseDir, "orgzly-git")
-        var success = false
-        try {
-            success = orgzlyGitPath.mkdirs()
-        } catch(error: SecurityException) {}
-        if (success || (orgzlyGitPath.exists() && orgzlyGitPath.list().size == 0)) {
-            binding.activityRepoGitDirectory.setText(orgzlyGitPath.path)
+        // Find an available directory name: orgzly-git, orgzly-git-2, orgzly-git-3, ...
+        val candidate = generateSequence(1) { it + 1 }
+            .map { n -> File(baseDir, if (n == 1) "orgzly-git" else "orgzly-git-$n") }
+            .first { !it.exists() || it.list()?.isEmpty() != false }
+        val created = try { candidate.mkdirs() } catch (_: SecurityException) { false }
+        if (created || (candidate.exists() && candidate.list()?.isEmpty() != false)) {
+            binding.activityRepoGitDirectory.setText(candidate.path)
         }
     }
 
@@ -307,7 +307,7 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
                         getString(R.string.git_clone_error_invalid_target_dir)
                     return
                 }
-                if (targetDirectory.list()!!.isNotEmpty()) {
+                if (targetDirectory.list()?.isNotEmpty() == true) {
                     binding.activityRepoGitDirectoryLayout.error =
                         getString(R.string.git_clone_error_target_not_empty)
                     return

--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoActivity.kt
@@ -218,8 +218,6 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
         }
     }
 
-    // TODO: Since we can create multiple syncs, this folder might be re-used, do we want to create
-    //       a new one if this directory is already used up?
     private fun createDefaultRepoFolder() {
         if (Environment.getExternalStorageState() != Environment.MEDIA_MOUNTED) {
             return
@@ -232,21 +230,10 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
         } else {
             File(Environment.getExternalStorageDirectory().path)
         }
-        // Find an available directory name: orgzly-git, orgzly-git-2, orgzly-git-3, ...
-        val candidate = generateSequence(1) { it + 1 }
-            .map { n -> File(baseDir, if (n == 1) "orgzly-git" else "orgzly-git-$n") }
-            .first { !it.exists() || it.list()?.isEmpty() != false }
-        val created = try { candidate.mkdirs() } catch (_: SecurityException) { false }
-        if (created || (candidate.exists() && candidate.list()?.isEmpty() != false)) {
+        val candidate = nextAvailableRepoDir(baseDir)
+        if (candidate.ensureDirectory()) {
             binding.activityRepoGitDirectory.setText(candidate.path)
         }
-    }
-
-    private fun isOnPublicExternalStorage(dir: File): Boolean {
-        val extDir = Environment.getExternalStorageDirectory().absolutePath
-        val appSpecificDir = getExternalFilesDir(null)?.absolutePath ?: return false
-        val path = dir.absolutePath
-        return path.startsWith(extDir) && !path.startsWith(appSpecificDir)
     }
 
     private fun setFromPreferences() {
@@ -302,23 +289,27 @@ class GitRepoActivity : CommonActivity(), GitPreferences {
                 save()
             } else {
                 val targetDirectory = File(binding.activityRepoGitDirectory.text.toString())
-                if (!targetDirectory.exists()) {
-                    binding.activityRepoGitDirectoryLayout.error =
-                        getString(R.string.git_clone_error_invalid_target_dir)
-                    return
-                }
-                if (targetDirectory.list()?.isNotEmpty() == true) {
-                    binding.activityRepoGitDirectoryLayout.error =
-                        getString(R.string.git_clone_error_target_not_empty)
-                    return
-                }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
-                    isOnPublicExternalStorage(targetDirectory)) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && isOnPublicExternalStorage(
+                        targetDirectory,
+                        Environment.getExternalStorageDirectory(),
+                        getExternalFilesDir(null))) {
                     val suggestedPath = getExternalFilesDir(null)?.let {
                         File(it, targetDirectory.name).absolutePath
                     } ?: targetDirectory.absolutePath
                     binding.activityRepoGitDirectoryLayout.error =
                         getString(R.string.git_clone_error_public_external_storage, suggestedPath)
+                    return
+                }
+                // The app-specific directory is hidden from file managers, so only we can
+                // create the target directory.
+                if (!targetDirectory.ensureDirectory()) {
+                    binding.activityRepoGitDirectoryLayout.error =
+                        getString(R.string.git_clone_error_invalid_target_dir)
+                    return
+                }
+                if (!targetDirectory.isEmptyOrMissing()) {
+                    binding.activityRepoGitDirectoryLayout.error =
+                        getString(R.string.git_clone_error_target_not_empty)
                     return
                 }
                 val repoScheme = getRepoScheme()

--- a/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoDirs.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repo/git/GitRepoDirs.kt
@@ -1,0 +1,27 @@
+package com.orgzly.android.ui.repo.git
+
+import java.io.File
+
+private const val DEFAULT_DIR_NAME = "orgzly-git"
+
+fun File.isEmptyOrMissing(): Boolean =
+    !exists() || (isDirectory && list()?.isEmpty() == true)
+
+fun File.ensureDirectory(): Boolean =
+    try {
+        isDirectory || mkdirs()
+    } catch (_: SecurityException) {
+        false
+    }
+
+/** orgzly-git, orgzly-git-2, orgzly-git-3, ... until one is free. */
+fun nextAvailableRepoDir(baseDir: File): File =
+    generateSequence(1) { it + 1 }
+        .map { File(baseDir, if (it == 1) DEFAULT_DIR_NAME else "$DEFAULT_DIR_NAME-$it") }
+        .first { it.isEmptyOrMissing() }
+
+/** On external storage, but outside the app-specific directory, so not writable on Android 11+. */
+fun isOnPublicExternalStorage(dir: File, externalDir: File, appSpecificDir: File?): Boolean =
+    appSpecificDir != null &&
+            dir.absolutePath.startsWith(externalDir.absolutePath) &&
+            !dir.absolutePath.startsWith(appSpecificDir.absolutePath)

--- a/app/src/main/java/com/orgzly/android/ui/repos/ReposActivity.kt
+++ b/app/src/main/java/com/orgzly/android/ui/repos/ReposActivity.kt
@@ -225,7 +225,12 @@ class ReposActivity : CommonActivity(), AdapterView.OnItemClickListener, Activit
             }
 
             R.id.repos_options_menu_item_new_git -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
+                val declaresManageStorage = packageManager.getPackageInfo(
+                    packageName, PackageManager.GET_PERMISSIONS
+                ).requestedPermissions?.contains(Manifest.permission.MANAGE_EXTERNAL_STORAGE) == true
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                    declaresManageStorage &&
+                    !Environment.isExternalStorageManager()) {
                     val uri = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
                     startActivity(
                         Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, uri))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,7 +191,7 @@
     <!-- TODO: I don't think we can say more than this for ssh authentication failures, but we probably want to -->
     <string name="git_clone_error_public_external_storage">This path is not supported on Android 11+. Use app storage instead, e.g.: %1$s</string>
     <string name="git_clone_error_invalid_repo">The remote address is not a git repo</string>
-    <string name="git_clone_error_invalid_target_dir">The target directory does not exist</string>
+    <string name="git_clone_error_invalid_target_dir">The target directory could not be created</string>
     <string name="git_clone_error_target_not_empty">The target directory is not empty</string>
     <string name="git_clone_error_uri_not_supported">The remote address is not supported</string>
     <string name="git_sync_error_failed_set_marker_branch">Failed to update marker branch</string>

--- a/app/src/test/java/com/orgzly/android/ui/repo/git/GitRepoDirsTest.kt
+++ b/app/src/test/java/com/orgzly/android/ui/repo/git/GitRepoDirsTest.kt
@@ -1,0 +1,113 @@
+package com.orgzly.android.ui.repo.git
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class GitRepoDirsTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun dir(name: String, vararg files: String) =
+        File(tmp.root, name).also { dir ->
+            dir.mkdirs()
+            files.forEach { File(dir, it).writeText("* Note") }
+        }
+
+    @Test
+    fun `first repo gets the plain default name`() {
+        assertEquals(File(tmp.root, "orgzly-git"), nextAvailableRepoDir(tmp.root))
+    }
+
+    @Test
+    fun `existing but empty directory is reused`() {
+        assertEquals(dir("orgzly-git"), nextAvailableRepoDir(tmp.root))
+    }
+
+    @Test
+    fun `second repo gets a suffixed name when the first one is in use`() {
+        dir("orgzly-git", "notes.org")
+
+        assertEquals(File(tmp.root, "orgzly-git-2"), nextAvailableRepoDir(tmp.root))
+    }
+
+    @Test
+    fun `suffix keeps incrementing past used directories`() {
+        listOf("orgzly-git", "orgzly-git-2", "orgzly-git-3").forEach { dir(it, "notes.org") }
+
+        assertEquals(File(tmp.root, "orgzly-git-4"), nextAvailableRepoDir(tmp.root))
+    }
+
+    @Test
+    fun `a file with the default name is skipped`() {
+        File(tmp.root, "orgzly-git").writeText("not a directory")
+
+        assertEquals(File(tmp.root, "orgzly-git-2"), nextAvailableRepoDir(tmp.root))
+    }
+
+    @Test
+    fun `ensureDirectory creates missing directories including parents`() {
+        val dir = File(tmp.root, "files/orgzly-git-2")
+
+        assertTrue(dir.ensureDirectory())
+        assertTrue(dir.isDirectory)
+    }
+
+    @Test
+    fun `ensureDirectory accepts an existing directory`() {
+        assertTrue(dir("orgzly-git").ensureDirectory())
+    }
+
+    @Test
+    fun `ensureDirectory fails when the path is an existing file`() {
+        assertFalse(File(tmp.root, "orgzly-git").also { it.writeText("x") }.ensureDirectory())
+    }
+
+    @Test
+    fun `ensureDirectory fails when the parent is not writable`() {
+        val parent = dir("readonly")
+        assertTrue(parent.setWritable(false))
+        try {
+            assertFalse(File(parent, "orgzly-git").ensureDirectory())
+        } finally {
+            parent.setWritable(true)
+        }
+    }
+
+    @Test
+    fun `app-specific directory is not public external storage`() {
+        val external = dir("emulated")
+        val appSpecific = File(external, "Android/data/com.orgzlyrevived/files")
+
+        assertFalse(isOnPublicExternalStorage(File(appSpecific, "orgzly-git"), external, appSpecific))
+    }
+
+    @Test
+    fun `documents directory is public external storage`() {
+        val external = dir("emulated")
+        val appSpecific = File(external, "Android/data/com.orgzlyrevived/files")
+
+        assertTrue(isOnPublicExternalStorage(File(external, "Documents/org"), external, appSpecific))
+    }
+
+    @Test
+    fun `paths outside external storage are not flagged`() {
+        val external = dir("emulated")
+        val appSpecific = File(external, "Android/data/com.orgzlyrevived/files")
+        val internal = File(tmp.root, "data/com.orgzlyrevived/files/orgzly-git")
+
+        assertFalse(isOnPublicExternalStorage(internal, external, appSpecific))
+    }
+
+    @Test
+    fun `missing app-specific directory means nothing is flagged`() {
+        val external = dir("emulated")
+
+        assertFalse(isOnPublicExternalStorage(File(external, "Documents/org"), external, null))
+    }
+}


### PR DESCRIPTION
Should resolve #1039 

Issues:
createDefaultRepoFolder() hardcodes the "orgzly-git" directory name,

ReposActivity also gates git repo setup behind MANAGE_EXTERNAL_STORAGE on API 30+, but the premium flavor doesn't declare this permission, so the settings toggle is greyed out.

- Auto-increment default repo directory (orgzly-git, orgzly-git-2, ...)
- Only prompt for MANAGE_EXTERNAL_STORAGE when declared in the manifest
- Guard against File.list() returning null