### PR TITLE
feat: Add refine button to menu when FAB force hidden

### DIFF
--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryFragment.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.View
 import android.widget.Toast
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.orgzly.R
@@ -184,6 +186,16 @@ abstract class QueryFragment :
         }
 
         listener?.onNoteNewRequestWithTemplate(result.notePlace, template)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.state.collectWithLifecycle { state ->
+            view.findViewById<MaterialToolbar?>(R.id.top_toolbar)?.let { topToolbar ->
+                topToolbar.menu.findItem(R.id.refine_search)?.isVisible =
+                    state.isForcingHideRefineButton
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModel.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/QueryViewModel.kt
@@ -46,6 +46,7 @@ data class QueryState(
     val isSimpleMode: Boolean,
     val showRefineButton: Boolean,
     val agendaDays: Int,
+    val isForcingHideRefineButton: Boolean,
 ) {
 
     companion object {
@@ -57,8 +58,9 @@ data class QueryState(
             emptyList(),
             QueryViewModel.ViewState.LOADING,
             isSimpleMode = true,
-            showRefineButton = true,
-            agendaDays = 0
+            showRefineButton = false,
+            agendaDays = 0,
+            isForcingHideRefineButton = false
         )
     }
 
@@ -72,6 +74,8 @@ sealed interface QueryEvent {
     data class ChangeQueryView(val query: String): QueryEvent
 
     data class Snackbar(val snackbar: QuerySnackbar): QueryEvent
+
+    data object OpenRefineSearch: QueryEvent
 }
 
 class QueryViewModel @AssistedInject constructor(
@@ -81,7 +85,7 @@ class QueryViewModel @AssistedInject constructor(
     private val filterMapper: SimpleFilterMapper,
     @Assisted private val initialQuery: String,
     @Assisted("isRawQuery") private val isRawQuery: Boolean,
-    @Assisted("forceHideRefineButton") private val forceHideRefineButton: Boolean,
+    @Assisted("forceHideRefineButton") forceHideRefineButton: Boolean,
     @Assisted private val owner: QueryViewModelOwner,
     @Assisted context: Context
 ) : CommonViewModel() {
@@ -101,6 +105,7 @@ class QueryViewModel @AssistedInject constructor(
     private val query = MutableStateFlow("")
     private val search = MutableStateFlow("")
     private val filter = MutableStateFlow(SimpleFilter())
+    private val _forceHideRefineButton = MutableStateFlow(forceHideRefineButton)
 
     private val allTags = dataRepository.selectAllTagsLiveData().asFlow()
     private val allBooks = dataRepository.getBooksLiveData().asFlow().mapLatest {
@@ -122,8 +127,9 @@ class QueryViewModel @AssistedInject constructor(
         allBooks,
         filter,
         appBar.currentMode,
-        isSimpleMode
-    ) { query, search, queryResult, allTags, allBooks, filter, appBarMode, isSimpleMode ->
+        isSimpleMode,
+        _forceHideRefineButton
+    ) { query, search, queryResult, allTags, allBooks, filter, appBarMode, isSimpleMode, forceHideRefineButton ->
         QueryState(
             when (isSimpleMode) {
                 true -> search
@@ -139,7 +145,8 @@ class QueryViewModel @AssistedInject constructor(
             },
             isSimpleMode,
             appBarMode == APP_BAR_DEFAULT_MODE && !forceHideRefineButton,
-            queryParser.parse(query).options.agendaDays
+            queryParser.parse(query).options.agendaDays,
+            forceHideRefineButton
         )
     }.state(QueryState.default)
 
@@ -281,6 +288,13 @@ class QueryViewModel @AssistedInject constructor(
                     }
                 }
             }
+        }
+    }
+
+    fun showRefineSearchButton() {
+        _forceHideRefineButton.value = false
+        viewModelScope.launch {
+            _events.send(QueryEvent.OpenRefineSearch)
         }
     }
 

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/SearchFilterScaffold.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/SearchFilterScaffold.kt
@@ -71,6 +71,7 @@ fun SearchFilterScaffold(
                 )
             }
             is QueryEvent.ChangeQueryView -> {}
+            is QueryEvent.OpenRefineSearch -> { sheetVisible = true }
         }
     }
 

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/agenda/AgendaFragment.kt
@@ -191,6 +191,8 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
                 sharedMainActivityViewModel.openDrawer()
             }
 
+            menu.findItem(R.id.refine_search)?.isVisible = viewModel.state.value.isForcingHideRefineButton
+
             setOnMenuItemClickListener { menuItem ->
                 when (menuItem.itemId) {
                     R.id.sync -> {
@@ -203,6 +205,10 @@ class AgendaFragment : QueryFragment(), OnViewHolderClickListener<AgendaItem> {
 
                     R.id.keep_screen_on -> {
                         dialog = ActivityUtils.keepScreenOnToggle(activity, menuItem)
+                    }
+
+                    R.id.refine_search -> {
+                        viewModel.showRefineSearchButton()
                     }
                 }
                 true

--- a/app/src/main/java/com/orgzly/android/ui/notes/query/search/SearchFragment.kt
+++ b/app/src/main/java/com/orgzly/android/ui/notes/query/search/SearchFragment.kt
@@ -187,6 +187,8 @@ class SearchFragment : QueryFragment(), OnViewHolderClickListener<NoteView> {
                 sharedMainActivityViewModel.openDrawer()
             }
 
+            menu.findItem(R.id.refine_search)?.isVisible = viewModel.state.value.isForcingHideRefineButton
+
             setOnMenuItemClickListener { menuItem ->
                 when (menuItem.itemId) {
                     R.id.sync -> {
@@ -199,6 +201,10 @@ class SearchFragment : QueryFragment(), OnViewHolderClickListener<NoteView> {
 
                     R.id.keep_screen_on -> {
                         dialog = ActivityUtils.keepScreenOnToggle(activity, menuItem)
+                    }
+
+                    R.id.refine_search -> {
+                        viewModel.showRefineSearchButton()
                     }
                 }
                 true

--- a/app/src/main/java/com/orgzly/android/ui/util/Combine.kt
+++ b/app/src/main/java/com/orgzly/android/ui/util/Combine.kt
@@ -119,3 +119,31 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
         )
     }
 }
+
+inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    flow7: Flow<T7>,
+    flow8: Flow<T8>,
+    flow9: Flow<T9>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R
+): Flow<R> {
+    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7, flow8, flow9) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+            args[6] as T7,
+            args[7] as T8,
+            args[8] as T9
+        )
+    }
+}

--- a/app/src/main/res/menu/query_actions.xml
+++ b/app/src/main/res/menu/query_actions.xml
@@ -16,4 +16,10 @@
         android:id="@+id/activity_action_settings"
         app:showAsAction="never"
         android:title="@string/settings"/>
+
+    <item
+        android:id="@+id/refine_search"
+        app:showAsAction="never"
+        android:visible="false"
+        android:title="@string/query_filter_search"/>
 </menu>


### PR DESCRIPTION
## Changes
Adds a refine button to the overflow menu on Search/Agenda fragment when the FloatingActionButton is force hidden (i.e. when the fragment is entered through a saved menu). Allows the action to remain less intrusive while still supporting the ability to refine existing searches. Follow up to #1038.

## Screenshots
<p align="center">
  <img width="40%" alt="Screenshot_20260816-091146" src="https://github.com/user-attachments/assets/a0b0134a-08c6-4bee-94f4-d32cc0566079" />
</p>
